### PR TITLE
Add possibility to change server tcp port in void setup. No more fixed port!

### DIFF
--- a/examples/WebServer/WebServer.ino
+++ b/examples/WebServer/WebServer.ino
@@ -30,7 +30,9 @@ IPAddress ip(192, 168, 1, 177);
 // Initialize the Ethernet server library
 // with the IP address and port you want to use
 // (port 80 is default for HTTP):
-EthernetServer server(80);
+//EthernetServer server(80);
+// User can now posticipate the port declaration in void setup()
+EthernetServer server();
 
 void setup() {
   // Open serial communications and wait for port to open:
@@ -42,7 +44,9 @@ void setup() {
 
   // start the Ethernet connection and the server:
   Ethernet.begin(mac, ip);
-  server.begin();
+  //server.begin();
+  //The tcp port used by server now can be a result of a eeprom.read (for example) or a normal int
+  server.begin(80);
   Serial.print("server is at ");
   Serial.println(Ethernet.localIP());
 }

--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -8,13 +8,16 @@ extern "C" {
 #include "EthernetClient.h"
 #include "EthernetServer.h"
 
-EthernetServer::EthernetServer(uint16_t port)
+EthernetServer::EthernetServer(uint16_t port) 
 {
   _port = port;
 }
 
-void EthernetServer::begin()
+EthernetServer::EthernetServer() {}
+
+void EthernetServer::begin(uint16_t port)
 {
+  _port = port;
   for (int sock = 0; sock < MAX_SOCK_NUM; sock++) {
     EthernetClient client(sock);
     if (client.status() == SnSR::CLOSED) {
@@ -24,6 +27,10 @@ void EthernetServer::begin()
       break;
     }
   }  
+}
+
+void EthernetServer::begin() {
+	begin(_port);
 }
 
 void EthernetServer::accept()

--- a/src/EthernetServer.h
+++ b/src/EthernetServer.h
@@ -12,7 +12,9 @@ private:
   void accept();
 public:
   EthernetServer(uint16_t);
+  EthernetServer();
   EthernetClient available();
+  virtual void begin(uint16_t);
   virtual void begin();
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);


### PR DESCRIPTION
Before this modification:

```cpp
EthernetServer server(80);
void setup() {
//some stuff here
server.begin(); //User can't change initial port value
//other stuff here
}
```

Now:

```cpp
EthernetServer server; //without port declaration but still working old declaration system...
void setup() {
//some stuff here
unsigned int tcp = EEPROM.read(x)
server.begin(tcp); //User can now use a different port, maybe saved in eprom directly from the sketch in a configuration page that permise to choice a value for the tcp port...
//other stuff here
}
```

Many thanks to Arduino's forum user: SukkoPera