### PR TITLE
Remove TODO related to non-standard ipv4 address notation

### DIFF
--- a/src/Dns.cpp
+++ b/src/Dns.cpp
@@ -57,8 +57,6 @@ void DNSClient::begin(const IPAddress& aDNSServer)
 
 int DNSClient::inet_aton(const char* address, IPAddress& result)
 {
-    // TODO: add support for "a", "a.b", "a.b.c" formats
-
     uint16_t acc = 0; // Accumulator
     uint8_t dots = 0;
 


### PR DESCRIPTION
For coherence with main Arduino repo, the feature request regarding
non-standard ipv4 addresses should be removed from sources.

See [this PR.](https://github.com/arduino/Arduino/pull/5823)

Signed-off-by: Patrick Roncagliolo <ronca.pat@gmail.com>