### PR TITLE
Update w5100.cpp

### DIFF
--- a/src/utility/w5100.cpp
+++ b/src/utility/w5100.cpp
@@ -36,7 +36,7 @@ void W5100Class::init(void)
   SPI.setDataMode(ETHERNET_SHIELD_SPI_CS, SPI_MODE0);
 #endif
   SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
-  writeMR(1<<RST);
+  writeMR(RST); 
   writeTMSR(0x55);
   writeRMSR(0x55);
   SPI.endTransaction();


### PR DESCRIPTION
Wrong constant used to perform w5100 reset (1<<0x80 instead 0x80)
As result - sporadic Ethernet init failure after application soft reset (by Watchdog timer for example)
Fixed