### PR TITLE
[DHCP] change return type int to uint8_t

### DIFF
--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -6,7 +6,7 @@
 #include "Dhcp.h"
 #include "utility/w5100.h"
 
-int DhcpClass::beginWithDHCP(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
+uint8_t DhcpClass::beginWithDHCP(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
 {
 	_dhcpLeaseTime=0;
 	_dhcpT1=0;
@@ -29,8 +29,8 @@ void DhcpClass::reset_DHCP_lease()
 	memset(_dhcpLocalIp, 0, 20);
 }
 
-	//return:0 on error, 1 if request is sent and response is received
-int DhcpClass::request_DHCP_lease()
+// return: 0 on error, 1 if request is sent and response is received
+uint8_t DhcpClass::request_DHCP_lease()
 {
 	uint8_t messageType = 0;
 
@@ -46,7 +46,7 @@ int DhcpClass::request_DHCP_lease()
 
 	presend_DHCP();
 
-	int result = 0;
+	uint8_t result = 0;
 
 	unsigned long startTime = millis();
 
@@ -349,9 +349,9 @@ uint8_t DhcpClass::parseDHCPResponse(unsigned long responseTimeout, uint32_t& tr
     3/DHCP_CHECK_REBIND_FAIL: rebind fail
     4/DHCP_CHECK_REBIND_OK: rebind success
 */
-int DhcpClass::checkLease()
+uint8_t DhcpClass::checkLease()
 {
-	int rc = DHCP_CHECK_NONE;
+	uint8_t rc = DHCP_CHECK_NONE;
 
 	unsigned long now = millis();
 	unsigned long elapsed = now - _lastCheckLeaseMillis;

--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -125,9 +125,9 @@ EthernetHardwareStatus EthernetClass::hardwareStatus()
 	}
 }
 
-int EthernetClass::maintain()
+uint8_t EthernetClass::maintain()
 {
-	int rc = DHCP_CHECK_NONE;
+	uint8_t rc = DHCP_CHECK_NONE;
 	if (_dhcp != NULL) {
 		// we have a pointer to dhcp, use it
 		rc = _dhcp->checkLease();

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -80,7 +80,7 @@ public:
 	// gain the rest of the configuration through DHCP.
 	// Returns 0 if the DHCP configuration failed, and 1 if it succeeded
 	static int begin(uint8_t *mac, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
-	static int maintain();
+	static uint8_t maintain();
 	static EthernetLinkStatus linkStatus();
 	static EthernetHardwareStatus hardwareStatus();
 
@@ -297,7 +297,7 @@ private:
 	uint8_t _dhcp_state;
 	EthernetUDP _dhcpUdpSocket;
 
-	int request_DHCP_lease();
+	uint8_t request_DHCP_lease();
 	void reset_DHCP_lease();
 	void presend_DHCP();
 	void send_DHCP_MESSAGE(uint8_t, uint16_t);
@@ -311,8 +311,8 @@ public:
 	IPAddress getDhcpServerIp();
 	IPAddress getDnsServerIp();
 
-	int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
-	int checkLease();
+	uint8_t beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
+	uint8_t checkLease();
 };
 
 


### PR DESCRIPTION
return type is just positive and does not use more than 1 byte