### PR TITLE
Adding ESP32 support and fix for ESP32 v 1.0.2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Michael Margolis   https://github.com/michaelmargolis
 Norbert Truchsess  https://github.com/ntruchsess
 Paul Stoffregen    https://github.com/PaulStoffregen
 per1234            https://github.com/per1234
+KMPElectronics     https://github.com/kmpelectronics
 Richard Sim
 Scott Fitzgerald   https://github.com/shfitz
 Thibaut Viard      https://github.com/aethaniel

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -219,6 +219,11 @@ public:
 	uint8_t status();
 	virtual int connect(IPAddress ip, uint16_t port);
 	virtual int connect(const char *host, uint16_t port);
+	// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
+#ifdef ESP32
+	virtual int connect(IPAddress ip, uint16_t port, int timeout);
+	virtual int connect(const char *host, uint16_t port, int timeout);
+#endif
 	virtual int availableForWrite(void);
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t *buf, size_t size);
@@ -253,11 +258,18 @@ private:
 class EthernetServer : public Server {
 private:
 	uint16_t _port;
+	// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
+	void init();
 public:
 	EthernetServer(uint16_t port) : _port(port) { }
 	EthernetClient available();
 	EthernetClient accept();
+	// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
+#ifdef ESP32
+	virtual void begin(uint16_t port = 0);
+#else
 	virtual void begin();
+#endif
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t *buf, size_t size);
 	virtual operator bool();

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -219,11 +219,6 @@ public:
 	uint8_t status();
 	virtual int connect(IPAddress ip, uint16_t port);
 	virtual int connect(const char *host, uint16_t port);
-	// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
-#ifdef ESP32
-	virtual int connect(IPAddress ip, uint16_t port, int timeout);
-	virtual int connect(const char *host, uint16_t port, int timeout);
-#endif
 	virtual int availableForWrite(void);
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t *buf, size_t size);
@@ -258,13 +253,11 @@ private:
 class EthernetServer : public Server {
 private:
 	uint16_t _port;
-	// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
-	void init();
+	void initSocket();
 public:
 	EthernetServer(uint16_t port) : _port(port) { }
 	EthernetClient available();
 	EthernetClient accept();
-	// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
 #ifdef ESP32
 	virtual void begin(uint16_t port = 0);
 #else

--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -69,21 +69,6 @@ int EthernetClient::connect(IPAddress ip, uint16_t port)
 	return 0;
 }
 
-// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
-#ifdef ESP32
-int EthernetClient::connect(const char * host, uint16_t port, int timeout)
-{
-	// timeout processing is not implemented.
-	return connect(host, port);
-}
-
-int EthernetClient::connect(IPAddress ip, uint16_t port, int timeout)
-{
-	// timeout processing is not implemented.
-	return connect(ip, port);
-}
-#endif
-
 int EthernetClient::availableForWrite(void)
 {
 	if (sockindex >= MAX_SOCK_NUM) return 0;

--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -69,6 +69,21 @@ int EthernetClient::connect(IPAddress ip, uint16_t port)
 	return 0;
 }
 
+// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
+#ifdef ESP32
+int EthernetClient::connect(const char * host, uint16_t port, int timeout)
+{
+	// timeout processing is not implemented.
+	return connect(host, port);
+}
+
+int EthernetClient::connect(IPAddress ip, uint16_t port, int timeout)
+{
+	// timeout processing is not implemented.
+	return connect(ip, port);
+}
+#endif
+
 int EthernetClient::availableForWrite(void)
 {
 	if (sockindex >= MAX_SOCK_NUM) return 0;

--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -24,9 +24,7 @@
 
 uint16_t EthernetServer::server_port[MAX_SOCK_NUM];
 
-
-// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
-void EthernetServer::init()
+void EthernetServer::initSocket()
 {
 	uint8_t sockindex = Ethernet.socketBegin(SnMR::TCP, _port);
 	if (sockindex < MAX_SOCK_NUM) {
@@ -38,7 +36,6 @@ void EthernetServer::init()
 	}
 }
 
-// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
 #ifdef ESP32
 void EthernetServer::begin(uint16_t port)
 {
@@ -46,12 +43,12 @@ void EthernetServer::begin(uint16_t port)
 		_port = port;
 	}
 
-	init();
+	initSocket();
 }
 #else
 void EthernetServer::begin()
 {
-	init();
+	initSocket();
 }
 #endif
 

--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -25,7 +25,8 @@
 uint16_t EthernetServer::server_port[MAX_SOCK_NUM];
 
 
-void EthernetServer::begin()
+// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
+void EthernetServer::init()
 {
 	uint8_t sockindex = Ethernet.socketBegin(SnMR::TCP, _port);
 	if (sockindex < MAX_SOCK_NUM) {
@@ -36,6 +37,23 @@ void EthernetServer::begin()
 		}
 	}
 }
+
+// 20190421 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
+#ifdef ESP32
+void EthernetServer::begin(uint16_t port)
+{
+	if (port) {
+		_port = port;
+	}
+
+	init();
+}
+#else
+void EthernetServer::begin()
+{
+	init();
+}
+#endif
 
 EthernetClient EthernetServer::available()
 {


### PR DESCRIPTION
We have added ESP32 support in Ethernet 2.0.0 library.  Especially for ESP32
v1.0.2. 
You can delete our comments where they are necessary.