### PR TITLE
compatibility for esp8266 core

### DIFF
--- a/examples/BarometricPressureWebServer/BarometricPressureWebServer.ino
+++ b/examples/BarometricPressureWebServer/BarometricPressureWebServer.ino
@@ -228,7 +228,7 @@ unsigned int readRegister(byte registerName, int numBytes) {
   // take the chip select low to select the device:
   digitalWrite(chipSelectPin, LOW);
   // send the device the register you want to read:
-  /*int command =*/ SPI.transfer(registerName);
+  SPI.transfer(registerName);
   // send a value of 0 to read the first byte returned:
   inByte = SPI.transfer(0x00);
 

--- a/examples/BarometricPressureWebServer/BarometricPressureWebServer.ino
+++ b/examples/BarometricPressureWebServer/BarometricPressureWebServer.ino
@@ -228,7 +228,7 @@ unsigned int readRegister(byte registerName, int numBytes) {
   // take the chip select low to select the device:
   digitalWrite(chipSelectPin, LOW);
   // send the device the register you want to read:
-  int command = SPI.transfer(registerName);
+  /*int command =*/ SPI.transfer(registerName);
   // send a value of 0 to read the first byte returned:
   inByte = SPI.transfer(0x00);
 

--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -83,7 +83,11 @@ void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress g
 	if (W5100.init() == 0) return;
 	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac);
-#if ARDUINO > 106 || TEENSYDUINO > 121
+#ifdef ESP8266
+	W5100.setIPAddress(&ip[0]);
+	W5100.setGatewayIp(&gateway[0]);
+	W5100.setSubnetMask(&subnet[0]);
+#elif ARDUINO > 106 || TEENSYDUINO > 121
 	W5100.setIPAddress(ip._address.bytes);
 	W5100.setGatewayIp(gateway._address.bytes);
 	W5100.setSubnetMask(subnet._address.bytes);

--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -454,6 +454,8 @@ extern W5100Class W5100;
 #ifndef UTIL_H
 #define UTIL_H
 
+#ifndef htons
+
 #define htons(x) ( (((x)<<8)&0xFF00) | (((x)>>8)&0xFF) )
 #define ntohs(x) htons(x)
 
@@ -462,5 +464,7 @@ extern W5100Class W5100;
                    ((x)>> 8 & 0x0000FF00UL) | \
                    ((x)>>24 & 0x000000FFUL) )
 #define ntohl(x) htonl(x)
+
+#endif // !defined(htons)
 
 #endif


### PR DESCRIPTION
This pull request:

*    Fixes a warning in example compilation
*    Allows to use local definitions for ntohs, htons, ntohl and htonl
*    In case of esp8266 and because of changes in IPAddress to allow IPv6,
    uses standard IPAddress API to get raw IP address.

About IPAddress, the proposed change is portable with current arduino API.
raw_address() would also be a another portable candidate relying on standard IPAddress.

Side note: this Ethernet library is planned to be integrated as a git submodule into esp8266 arduino core repository and replace the old one that was copied and locally patched.