### PR TITLE
Added MKR Vidor-4000 for Arduino MKR Vidor-4000

### DIFF
--- a/src/utility/w5100.cpp
+++ b/src/utility/w5100.cpp
@@ -24,7 +24,7 @@
 
 // MKR boards default to pin 5 for MKR ETH
 // Pins 8-10 are MOSI/SCK/MISO on MRK, so don't use pin 10
-#elif defined(USE_ARDUINO_MKR_PIN_LAYOUT) || defined(ARDUINO_SAMD_MKRZERO) || defined(ARDUINO_SAMD_MKR1000) || defined(ARDUINO_SAMD_MKRFox1200) || defined(ARDUINO_SAMD_MKRGSM1400) || defined(ARDUINO_SAMD_MKRWAN1300)
+#elif defined(USE_ARDUINO_MKR_PIN_LAYOUT) || defined(ARDUINO_SAMD_MKRZERO) || defined(ARDUINO_SAMD_MKR1000) || defined(ARDUINO_SAMD_MKRFox1200) || defined(ARDUINO_SAMD_MKRGSM1400) || defined(ARDUINO_SAMD_MKRWAN1300) || defined(ARDUINO_SAMD_MKRVIDOR4000)
 #define SS_PIN_DEFAULT  5
 
 // For boards using AVR, assume shields with SS on pin 10


### PR DESCRIPTION
'Default SS pin setting' is missing Arduino MKR Vidor 4000.

So I added `ARDUINO_SAMD_MKRVIDOR4000` on `/src/utility/w5100.cpp`.

Please accept this pull request.