### PR TITLE
Made Ethernet useable on 'Esp32 Dev Module'.

### DIFF
--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -219,6 +219,18 @@ public:
 	uint8_t status();
 	virtual int connect(IPAddress ip, uint16_t port);
 	virtual int connect(const char *host, uint16_t port);
+#ifdef ESP32
+	int connect(IPAddress ip, uint16_t port, int timeout)
+	{
+		connect(ip, port);
+		setConnectionTimeout(timeout);
+	}
+	int connect(const char* host, uint16_t port, int timeout)
+	{
+		connect(host, port);
+		setConnectionTimeout(timeout);
+	}
+#endif
 	virtual int availableForWrite(void);
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t *buf, size_t size);
@@ -258,6 +270,12 @@ public:
 	EthernetClient available();
 	EthernetClient accept();
 	virtual void begin();
+#ifdef ESP32
+	void begin(uint16_t port)
+	{
+		_port = port;
+	}
+#endif
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t *buf, size_t size);
 	virtual operator bool();


### PR DESCRIPTION
Espressif's BSP changes the Client class and Server class's definition. When compiling on 'Esp32 Dev Module, we will receive messages indicating there are some pure virtual functions which are not implemented.
Adding these override functions will solve the following issues:

https://github.com/arduino-libraries/Ethernet/issues/97
https://github.com/arduino-libraries/Ethernet/issues/106
https://github.com/espressif/arduino-esp32/issues/2786
