### PR TITLE
Add support for Teensy 4.0

### DIFF
--- a/src/utility/w5100.cpp
+++ b/src/utility/w5100.cpp
@@ -65,6 +65,9 @@ W5100Class W5100;
   uint8_t W5100Class::ss_pin_mask;
 #elif defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK66FX1M0__) || defined(__MK64FX512__)
   volatile uint8_t * W5100Class::ss_pin_reg;
+#elif defined(__IMXRT1062__)
+  volatile uint32_t * W5100Class::ss_pin_reg;
+  uint32_t W5100Class::ss_pin_mask;
 #elif defined(__MKL26Z64__)
   volatile uint8_t * W5100Class::ss_pin_reg;
   uint8_t W5100Class::ss_pin_mask;

--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -360,6 +360,20 @@ private:
 	inline static void resetSS() {
 		*(ss_pin_reg+128) = 1;
 	}
+#elif defined(__IMXRT1062__)
+	static volatile uint32_t *ss_pin_reg;
+	static uint32_t ss_pin_mask;
+	inline static void initSS() {
+		ss_pin_reg = portOutputRegister(digitalPinToPort(ss_pin));
+		ss_pin_mask = digitalPinToBitMask(ss_pin);
+		pinMode(ss_pin, OUTPUT);
+	}
+	inline static void setSS() {
+		*(ss_pin_reg+34) = ss_pin_mask;
+	}
+	inline static void resetSS() {
+		*(ss_pin_reg+33) = ss_pin_mask;
+	}
 #elif defined(__MKL26Z64__)
 	static volatile uint8_t *ss_pin_reg;
 	static uint8_t ss_pin_mask;


### PR DESCRIPTION
The latest version of Ethernet works well with a W5500 on my Teensy 3.6, but not at all with the same W5500 on my Teensy 4.0 (hardware not supported error).

Within this pull request, I've added support for Teensy 4.0 by adding__IMXRT1062__ specific implementations for initSS / setSS / resetSS. 

After these additions, I was able to run the WebClient example with DHCP on my Teensy 4.0 without any problems.