### PR TITLE
Run with any SPI port on boards with multiple SPI

### DIFF
--- a/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
+++ b/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
@@ -13,10 +13,18 @@
   by Tom Igoe
   modified 02 Sept 2015
   by Arturo Guadalupi
+  modified 23 May 2020 by KooLru
 
  */
 
 #include <SPI.h>
+
+#define MY_SERIAL Serial
+//#define MY_SERIAL Serial1 // Serial 1
+
+//SPIClass SPI_1((uint8_t)PA7, (uint8_t)PA6, (uint8_t)PA5);  // SPI1 on STM32F103xB Bluepill 
+SPIClass SPI_2(PB15, PB14, PB13);     // SPI2 on STM32F103xB Bluepill 
+
 #include <Ethernet.h>
 
 // Enter a MAC address for your controller below.
@@ -26,65 +34,79 @@ byte mac[] = {
 };
 
 void setup() {
-  // You can use Ethernet.init(pin) to configure the CS pin
+
+  // Open serial communications and wait for port to open:
+  MY_SERIAL.begin(9600);
+  while (!Serial1) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // You can use Ethernet.init(pin) to configure the CS pin ans SPI
   //Ethernet.init(10);  // Most Arduino shields
   //Ethernet.init(5);   // MKR ETH shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
   //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
   //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
-
-  // Open serial communications and wait for port to open:
-  Serial.begin(9600);
-  while (!Serial) {
-    ; // wait for serial port to connect. Needed for native USB port only
-  }
-
+    
+  //Ethernet.init((uint8_t)PA4);  // SPI1 on STM32 Bluepill 
+  Ethernet.init(SPI_2, PB12);  // SPI2 on STM32 Bluepill 
+  
   // start the Ethernet connection:
-  Serial.println("Initialize Ethernet with DHCP:");
+  MY_SERIAL.println("Initialize Ethernet with DHCP:");
   if (Ethernet.begin(mac) == 0) {
-    Serial.println("Failed to configure Ethernet using DHCP");
+    MY_SERIAL.println("Failed to configure Ethernet using DHCP");
     if (Ethernet.hardwareStatus() == EthernetNoHardware) {
-      Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
+      MY_SERIAL.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
     } else if (Ethernet.linkStatus() == LinkOFF) {
-      Serial.println("Ethernet cable is not connected.");
+      MY_SERIAL.println("Ethernet cable is not connected.");
     }
     // no point in carrying on, so do nothing forevermore:
     while (true) {
       delay(1);
     }
   }
+
+  //print chip info
+  if (Ethernet.hardwareStatus() == EthernetW5100) 
+    MY_SERIAL.println("Ethernet shield W5100");
+  else if (Ethernet.hardwareStatus() == EthernetW5200) 
+    MY_SERIAL.println("Ethernet shield W5200");
+  else if (Ethernet.hardwareStatus() == EthernetW5500) 
+    MY_SERIAL.println("Ethernet shield W5500");
+
+  
   // print your local IP address:
-  Serial.print("My IP address: ");
-  Serial.println(Ethernet.localIP());
+  MY_SERIAL.print("My IP address: ");
+  MY_SERIAL.println(Ethernet.localIP());
 }
 
 void loop() {
   switch (Ethernet.maintain()) {
     case 1:
       //renewed fail
-      Serial.println("Error: renewed fail");
+      MY_SERIAL.println("Error: renewed fail");
       break;
 
     case 2:
       //renewed success
-      Serial.println("Renewed success");
+      MY_SERIAL.println("Renewed success");
       //print your local IP address:
-      Serial.print("My IP address: ");
-      Serial.println(Ethernet.localIP());
+      MY_SERIAL.print("My IP address: ");
+      MY_SERIAL.println(Ethernet.localIP());
       break;
 
     case 3:
       //rebind fail
-      Serial.println("Error: rebind fail");
+      MY_SERIAL.println("Error: rebind fail");
       break;
 
     case 4:
       //rebind success
-      Serial.println("Rebind success");
+      MY_SERIAL.println("Rebind success");
       //print your local IP address:
-      Serial.print("My IP address: ");
-      Serial.println(Ethernet.localIP());
+      MY_SERIAL.print("My IP address: ");
+      MY_SERIAL.println(Ethernet.localIP());
       break;
 
     default:
@@ -92,4 +114,3 @@ void loop() {
       break;
   }
 }
-

--- a/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
+++ b/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
@@ -23,7 +23,7 @@
 //#define MY_SERIAL Serial1 // Serial 1
 
 //SPIClass SPI_1((uint8_t)PA7, (uint8_t)PA6, (uint8_t)PA5);  // SPI1 on STM32F103xB Bluepill 
-SPIClass SPI_2(PB15, PB14, PB13);     // SPI2 on STM32F103xB Bluepill 
+//SPIClass SPI_2(PB15, PB14, PB13);     // SPI2 on STM32F103xB Bluepill 
 
 #include <Ethernet.h>
 
@@ -50,7 +50,7 @@ void setup() {
   //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
     
   //Ethernet.init((uint8_t)PA4);  // SPI1 on STM32 Bluepill 
-  Ethernet.init(SPI_2, PB12);  // SPI2 on STM32 Bluepill 
+  //Ethernet.init(SPI_2, PB12);  // SPI2 on STM32 Bluepill 
   
   // start the Ethernet connection:
   MY_SERIAL.println("Initialize Ethernet with DHCP:");

--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -33,21 +33,21 @@ int EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long resp
 
 	// Initialise the basic info
 	if (W5100.init() == 0) return 0;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac);
 	W5100.setIPAddress(IPAddress(0,0,0,0).raw_address());
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 
 	// Now try to get our config info from a DHCP server
 	int ret = _dhcp->beginWithDHCP(mac, timeout, responseTimeout);
 	if (ret == 1) {
 		// We've successfully found a DHCP server and got our configuration
 		// info, so set things accordingly
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 		W5100.setIPAddress(_dhcp->getLocalIp().raw_address());
 		W5100.setGatewayIp(_dhcp->getGatewayIp().raw_address());
 		W5100.setSubnetMask(_dhcp->getSubnetMask().raw_address());
-		SPI.endTransaction();
+		W5100.getSPI()->endTransaction();
 		_dnsServerAddress = _dhcp->getDnsServerIp();
 		socketPortRand(micros());
 	}
@@ -81,7 +81,7 @@ void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress g
 void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet)
 {
 	if (W5100.init() == 0) return;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac);
 #ifdef ESP8266
 	W5100.setIPAddress(&ip[0]);
@@ -96,13 +96,18 @@ void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress g
 	W5100.setGatewayIp(gateway._address);
 	W5100.setSubnetMask(subnet._address);
 #endif
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	_dnsServerAddress = dns;
 }
 
 void EthernetClass::init(uint8_t sspin)
 {
 	W5100.setSS(sspin);
+}
+
+void EthernetClass::init(SPIClass& spi, uint8_t sspin)
+{
+	W5100.setSPI(spi, sspin);
 }
 
 EthernetLinkStatus EthernetClass::linkStatus()
@@ -138,11 +143,11 @@ int EthernetClass::maintain()
 		case DHCP_CHECK_RENEW_OK:
 		case DHCP_CHECK_REBIND_OK:
 			//we might have got a new IP.
-			SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+			W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 			W5100.setIPAddress(_dhcp->getLocalIp().raw_address());
 			W5100.setGatewayIp(_dhcp->getGatewayIp().raw_address());
 			W5100.setSubnetMask(_dhcp->getSubnetMask().raw_address());
-			SPI.endTransaction();
+			W5100.getSPI()->endTransaction();
 			_dnsServerAddress = _dhcp->getDnsServerIp();
 			break;
 		default:
@@ -156,82 +161,82 @@ int EthernetClass::maintain()
 
 void EthernetClass::MACAddress(uint8_t *mac_address)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getMACAddress(mac_address);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 }
 
 IPAddress EthernetClass::localIP()
 {
 	IPAddress ret;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getIPAddress(ret.raw_address());
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return ret;
 }
 
 IPAddress EthernetClass::subnetMask()
 {
 	IPAddress ret;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getSubnetMask(ret.raw_address());
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return ret;
 }
 
 IPAddress EthernetClass::gatewayIP()
 {
 	IPAddress ret;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getGatewayIp(ret.raw_address());
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return ret;
 }
 
 void EthernetClass::setMACAddress(const uint8_t *mac_address)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac_address);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 }
 
 void EthernetClass::setLocalIP(const IPAddress local_ip)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	IPAddress ip = local_ip;
 	W5100.setIPAddress(ip.raw_address());
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 }
 
 void EthernetClass::setSubnetMask(const IPAddress subnet)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	IPAddress ip = subnet;
 	W5100.setSubnetMask(ip.raw_address());
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 }
 
 void EthernetClass::setGatewayIP(const IPAddress gateway)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	IPAddress ip = gateway;
 	W5100.setGatewayIp(ip.raw_address());
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 }
 
 void EthernetClass::setRetransmissionTimeout(uint16_t milliseconds)
 {
 	if (milliseconds > 6553) milliseconds = 6553;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setRetransmissionTime(milliseconds * 10);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 }
 
 void EthernetClass::setRetransmissionCount(uint8_t num)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setRetransmissionCount(num);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 }
 
 

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -52,6 +52,8 @@
 #include "Client.h"
 #include "Server.h"
 #include "Udp.h"
+#include "SPI.h"
+
 
 enum EthernetLinkStatus {
 	Unknown,
@@ -74,6 +76,7 @@ class DhcpClass;
 class EthernetClass {
 private:
 	static IPAddress _dnsServerAddress;
+
 	static DhcpClass* _dhcp;
 public:
 	// Initialise the Ethernet shield to use the provided MAC address and
@@ -84,12 +87,14 @@ public:
 	static EthernetLinkStatus linkStatus();
 	static EthernetHardwareStatus hardwareStatus();
 
-	// Manaul configuration
+	// Manual configuration
 	static void begin(uint8_t *mac, IPAddress ip);
 	static void begin(uint8_t *mac, IPAddress ip, IPAddress dns);
 	static void begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress gateway);
 	static void begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet);
+	
 	static void init(uint8_t sspin = 10);
+	static void init(SPIClass& spi_device, uint8_t sspin);
 
 	static void MACAddress(uint8_t *mac_address);
 	static IPAddress localIP();

--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -182,9 +182,9 @@ uint16_t EthernetClient::localPort()
 {
 	if (sockindex >= MAX_SOCK_NUM) return 0;
 	uint16_t port;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	port = W5100.readSnPORT(sockindex);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return port;
 }
 
@@ -194,9 +194,9 @@ IPAddress EthernetClient::remoteIP()
 {
 	if (sockindex >= MAX_SOCK_NUM) return IPAddress((uint32_t)0);
 	uint8_t remoteIParray[4];
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.readSnDIPR(sockindex, remoteIParray);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return IPAddress(remoteIParray);
 }
 
@@ -206,9 +206,9 @@ uint16_t EthernetClient::remotePort()
 {
 	if (sockindex >= MAX_SOCK_NUM) return 0;
 	uint16_t port;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	port = W5100.readSnDPORT(sockindex);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return port;
 }
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -71,7 +71,7 @@ uint8_t EthernetClass::socketBegin(uint8_t protocol, uint16_t port)
 	if (chip == 51) maxindex = 4; // W5100 chip never supports more than 4 sockets
 #endif
 	//Serial.printf("W5000socket begin, protocol=%d, port=%d\n", protocol, port);
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	// look at all the hardware sockets, use any that are closed (unused)
 	for (s=0; s < maxindex; s++) {
 		status[s] = W5100.readSnSR(s);
@@ -95,7 +95,7 @@ uint8_t EthernetClass::socketBegin(uint8_t protocol, uint16_t port)
 		if (stat == SnSR::CLOSE_WAIT) goto closemakesocket;
 	}
 #endif
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return MAX_SOCK_NUM; // all sockets are in use
 closemakesocket:
 	//Serial.printf("W5000socket close\n");
@@ -119,7 +119,7 @@ makesocket:
 	state[s].RX_inc = 0;
 	state[s].TX_FSR = 0;
 	//Serial.printf("W5000socket prot=%d, RX_RD=%d\n", W5100.readSnMR(s), state[s].RX_RD);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return s;
 }
 
@@ -135,7 +135,7 @@ uint8_t EthernetClass::socketBeginMulticast(uint8_t protocol, IPAddress ip, uint
 	if (chip == 51) maxindex = 4; // W5100 chip never supports more than 4 sockets
 #endif
 	//Serial.printf("W5000socket begin, protocol=%d, port=%d\n", protocol, port);
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	// look at all the hardware sockets, use any that are closed (unused)
 	for (s=0; s < maxindex; s++) {
 		status[s] = W5100.readSnSR(s);
@@ -159,7 +159,7 @@ uint8_t EthernetClass::socketBeginMulticast(uint8_t protocol, IPAddress ip, uint
 		if (stat == SnSR::CLOSE_WAIT) goto closemakesocket;
 	}
 #endif
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return MAX_SOCK_NUM; // all sockets are in use
 closemakesocket:
 	//Serial.printf("W5000socket close\n");
@@ -191,16 +191,16 @@ makesocket:
 	state[s].RX_inc = 0;
 	state[s].TX_FSR = 0;
 	//Serial.printf("W5000socket prot=%d, RX_RD=%d\n", W5100.readSnMR(s), state[s].RX_RD);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return s;
 }
 // Return the socket's status
 //
 uint8_t EthernetClass::socketStatus(uint8_t s)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	uint8_t status = W5100.readSnSR(s);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return status;
 }
 
@@ -209,9 +209,9 @@ uint8_t EthernetClass::socketStatus(uint8_t s)
 //
 void EthernetClass::socketClose(uint8_t s)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.execCmdSn(s, Sock_CLOSE);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 }
 
 
@@ -219,13 +219,13 @@ void EthernetClass::socketClose(uint8_t s)
 //
 uint8_t EthernetClass::socketListen(uint8_t s)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	if (W5100.readSnSR(s) != SnSR::INIT) {
-		SPI.endTransaction();
+		W5100.getSPI()->endTransaction();
 		return 0;
 	}
 	W5100.execCmdSn(s, Sock_LISTEN);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return 1;
 }
 
@@ -235,11 +235,11 @@ uint8_t EthernetClass::socketListen(uint8_t s)
 void EthernetClass::socketConnect(uint8_t s, uint8_t * addr, uint16_t port)
 {
 	// set destination IP
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.writeSnDIPR(s, addr);
 	W5100.writeSnDPORT(s, port);
 	W5100.execCmdSn(s, Sock_CONNECT);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 }
 
 
@@ -248,9 +248,9 @@ void EthernetClass::socketConnect(uint8_t s, uint8_t * addr, uint16_t port)
 //
 void EthernetClass::socketDisconnect(uint8_t s)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.execCmdSn(s, Sock_DISCON);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 }
 
 
@@ -305,7 +305,7 @@ int EthernetClass::socketRecv(uint8_t s, uint8_t *buf, int16_t len)
 {
 	// Check how much data is available
 	int ret = state[s].RX_RSR;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	if (ret < len) {
 		uint16_t rsr = getSnRX_RSR(s);
 		ret = rsr - state[s].RX_inc;
@@ -342,7 +342,7 @@ int EthernetClass::socketRecv(uint8_t s, uint8_t *buf, int16_t len)
 			state[s].RX_inc = inc;
 		}
 	}
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	//Serial.printf("socketRecv, ret=%d\n", ret);
 	return ret;
 }
@@ -351,9 +351,9 @@ uint16_t EthernetClass::socketRecvAvailable(uint8_t s)
 {
 	uint16_t ret = state[s].RX_RSR;
 	if (ret == 0) {
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 		uint16_t rsr = getSnRX_RSR(s);
-		SPI.endTransaction();
+		W5100.getSPI()->endTransaction();
 		ret = rsr - state[s].RX_inc;
 		state[s].RX_RSR = ret;
 		//Serial.printf("sockRecvAvailable s=%d, RX_RSR=%d\n", s, ret);
@@ -366,10 +366,10 @@ uint16_t EthernetClass::socketRecvAvailable(uint8_t s)
 uint8_t EthernetClass::socketPeek(uint8_t s)
 {
 	uint8_t b;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	uint16_t ptr = state[s].RX_RD;
 	W5100.read((ptr & W5100.SMASK) + W5100.RBASE(s), &b, 1);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return b;
 }
 
@@ -433,10 +433,10 @@ uint16_t EthernetClass::socketSend(uint8_t s, const uint8_t * buf, uint16_t len)
 
 	// if freebuf is available, start.
 	do {
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 		freesize = getSnTX_FSR(s);
 		status = W5100.readSnSR(s);
-		SPI.endTransaction();
+		W5100.getSPI()->endTransaction();
 		if ((status != SnSR::ESTABLISHED) && (status != SnSR::CLOSE_WAIT)) {
 			ret = 0;
 			break;
@@ -445,7 +445,7 @@ uint16_t EthernetClass::socketSend(uint8_t s, const uint8_t * buf, uint16_t len)
 	} while (freesize < ret);
 
 	// copy data
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	write_data(s, 0, (uint8_t *)buf, ret);
 	W5100.execCmdSn(s, Sock_SEND);
 
@@ -453,16 +453,16 @@ uint16_t EthernetClass::socketSend(uint8_t s, const uint8_t * buf, uint16_t len)
 	while ( (W5100.readSnIR(s) & SnIR::SEND_OK) != SnIR::SEND_OK ) {
 		/* m2008.01 [bj] : reduce code */
 		if ( W5100.readSnSR(s) == SnSR::CLOSED ) {
-			SPI.endTransaction();
+			W5100.getSPI()->endTransaction();
 			return 0;
 		}
-		SPI.endTransaction();
+		W5100.getSPI()->endTransaction();
 		yield();
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	}
 	/* +2008.01 bj */
 	W5100.writeSnIR(s, SnIR::SEND_OK);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return ret;
 }
 
@@ -470,10 +470,10 @@ uint16_t EthernetClass::socketSendAvailable(uint8_t s)
 {
 	uint8_t status=0;
 	uint16_t freesize=0;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	freesize = getSnTX_FSR(s);
 	status = W5100.readSnSR(s);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	if ((status == SnSR::ESTABLISHED) || (status == SnSR::CLOSE_WAIT)) {
 		return freesize;
 	}
@@ -484,7 +484,7 @@ uint16_t EthernetClass::socketBufferData(uint8_t s, uint16_t offset, const uint8
 {
 	//Serial.printf("  bufferData, offset=%d, len=%d\n", offset, len);
 	uint16_t ret =0;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	uint16_t txfree = getSnTX_FSR(s);
 	if (len > txfree) {
 		ret = txfree; // check size not to exceed MAX size.
@@ -492,7 +492,7 @@ uint16_t EthernetClass::socketBufferData(uint8_t s, uint16_t offset, const uint8
 		ret = len;
 	}
 	write_data(s, offset, buf, ret);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return ret;
 }
 
@@ -502,16 +502,16 @@ bool EthernetClass::socketStartUDP(uint8_t s, uint8_t* addr, uint16_t port)
 	  ((port == 0x00)) ) {
 		return false;
 	}
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.writeSnDIPR(s, addr);
 	W5100.writeSnDPORT(s, port);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 	return true;
 }
 
 bool EthernetClass::socketSendUDP(uint8_t s)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.execCmdSn(s, Sock_SEND);
 
 	/* +2008.01 bj */
@@ -519,18 +519,18 @@ bool EthernetClass::socketSendUDP(uint8_t s)
 		if (W5100.readSnIR(s) & SnIR::TIMEOUT) {
 			/* +2008.01 [bj]: clear interrupt */
 			W5100.writeSnIR(s, (SnIR::SEND_OK|SnIR::TIMEOUT));
-			SPI.endTransaction();
+			W5100.getSPI()->endTransaction();
 			//Serial.printf("sendUDP timeout\n");
 			return false;
 		}
-		SPI.endTransaction();
+		W5100.getSPI()->endTransaction();
 		yield();
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		W5100.getSPI()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	}
 
 	/* +2008.01 bj */
 	W5100.writeSnIR(s, SnIR::SEND_OK);
-	SPI.endTransaction();
+	W5100.getSPI()->endTransaction();
 
 	//Serial.printf("sendUDP ok\n");
 	/* Sent ok */

--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -298,6 +298,7 @@ public:
 private:
   static uint8_t chip;
   static uint8_t ss_pin;
+  static SPIClass* spi_device;
   static uint8_t softReset(void);
   static uint8_t isW5100(void);
   static uint8_t isW5200(void);
@@ -332,6 +333,13 @@ public:
     return false;
   }
   static void setSS(uint8_t pin) { ss_pin = pin; }
+  static void setSPI(SPIClass& spi, uint8_t pin) { 
+		spi_device = &spi; 
+		ss_pin = pin;
+	}
+  static SPIClass* getSPI() { 
+		return  spi_device; 
+	}
 
 private:
 #if defined(__AVR__)


### PR DESCRIPTION
For use another than defined SPI "port", you need:

0. Declare an SPI class object with appropriate pins 

**SPIClass SPI_2(PB15, PB14, PB13);**     

I have try SPI2 on STM32F103xB also known as "Blue pill"

1.  Call Ethernet.init()

**Ethernet.init(SPI_2, PB12);**  

2. Profit!

I also add this line in DhcpAddressPrinter sample, and define for Serial port, for debug on boards with more than one UART