### PR TITLE
Missing virtual destructor results in compiler warning

### DIFF
--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -215,6 +215,7 @@ class EthernetClient : public Client {
 public:
 	EthernetClient() : sockindex(MAX_SOCK_NUM), _timeout(1000) { }
 	EthernetClient(uint8_t s) : sockindex(s), _timeout(1000) { }
+	virtual ~EthernetClient() {};
 
 	uint8_t status();
 	virtual int connect(IPAddress ip, uint16_t port);


### PR DESCRIPTION
When `delete`ing an EthernetClient object, the compiler throws the following warning:
`warning: deleting object of polymorphic class type 'EthernetClient' which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]`
Adding a virtual destructor solves this problem, see also here:
https://stackoverflow.com/questions/43282826/suppress-delete-non-virtual-dtor-warning-when-using-a-protected-non-virtual-dest