### PR TITLE
Use GitHub Actions for continuous integration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = nd,
+check-filenames =
+check-hidden =
+skip = ./.git

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -1,0 +1,28 @@
+name: Check Arduino
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by new rules added to Arduino Lint.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v1
+        with:
+          compliance: specification
+          library-manager: update
+          # Always use this setting for official repositories. Remove for 3rd party projects.
+          official: true
+          project-type: library

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,6 +23,9 @@ jobs:
     name: ${{ matrix.board.fqbn }}
     runs-on: ubuntu-latest
 
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+
     strategy:
       fail-fast: false
 
@@ -97,3 +100,12 @@ jobs:
             # See: https://github.com/arduino/compile-sketches#libraries
           sketch-paths: |
             - examples
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      - name: Save sketches report as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,99 @@
+name: Compile Examples
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to external resources (libraries, platforms).
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.board.fqbn }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: arduino:avr:nano
+            platforms: |
+              - name: arduino:avr
+          - fqbn: arduino:avr:mega
+            platforms: |
+              - name: arduino:avr
+          - fqbn: arduino:avr:leonardo
+            platforms: |
+              - name: arduino:avr
+          - fqbn: arduino:megaavr:uno2018
+            platforms: |
+              - name: arduino:megaavr
+          - fqbn: arduino:megaavr:nona4809
+            platforms: |
+              - name: arduino:megaavr
+          - fqbn: arduino:sam:arduino_due_x_dbg
+            platforms: |
+              - name: arduino:sam
+          - fqbn: arduino:samd:arduino_zero_edbg
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkr1000
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrzero
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrwifi1010
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrfox1200
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrwan1300
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrwan1310
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrgsm1400
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrnb1500
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrvidor4000
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:nano_33_iot
+            platforms: |
+              - name: arduino:samd
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          libraries: |
+            # Install the library from the local path.
+            - source-path: ./
+            # Additional library dependencies can be listed here.
+            # See: https://github.com/arduino/compile-sketches#libraries
+          sketch-paths: |
+            - examples

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,24 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.yml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    # Note: GitHub Actions periodically has outages which result in workflow failures.
+    # In this event, the workflows will start passing again once the service recovers.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,3 @@
-
 Alberto Panu       https://github.com/bigjohnson
 Alasdair Allan     https://github.com/aallan
 Alice Pintus       https://github.com/00alis
@@ -33,6 +32,5 @@ Richard Sim
 Scott Fitzgerald   https://github.com/shfitz
 Thibaut Viard      https://github.com/aethaniel
 Tom Igoe           https://github.com/tigoe
-WizNet             http://www.wiznet.co.kr
+WIZnet             http://www.wiznet.co.kr
 Zach Eveland       https://github.com/zeveland
-

--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@
 
 = {repository-name} Library for Arduino =
 
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml/badge.svg["Check Arduino status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml"]
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 With the Arduino Ethernet Shield, this library allows an Arduino board to connect to the internet.

--- a/README.adoc
+++ b/README.adoc
@@ -1,9 +1,14 @@
-= Ethernet Library for Arduino =
+:repository-owner: arduino-libraries
+:repository-name: Ethernet
+
+= {repository-name} Library for Arduino =
+
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 With the Arduino Ethernet Shield, this library allows an Arduino board to connect to the internet.
 
 For more information about this library please visit us at
-https://www.arduino.cc/en/Reference/Ethernet
+https://www.arduino.cc/en/Reference/{repository-name}
 
 == License ==
 

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,7 @@
 = {repository-name} Library for Arduino =
 
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml/badge.svg["Check Arduino status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml"]
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/compile-examples.yml/badge.svg["Compile Examples status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/compile-examples.yml"]
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 With the Arduino Ethernet Shield, this library allows an Arduino board to connect to the internet.

--- a/examples/AdvancedChatServer/AdvancedChatServer.ino
+++ b/examples/AdvancedChatServer/AdvancedChatServer.ino
@@ -5,7 +5,7 @@
  to all connected clients but the client the message comes from.
  To use, telnet to your device's IP address and type.
  You can see the client's input in the serial monitor as well.
- Using an Arduino Wiznet Ethernet shield.
+ Using an Arduino WIZnet Ethernet shield.
 
  Circuit:
  * Ethernet shield attached to pins 10, 11, 12, 13
@@ -42,11 +42,11 @@ EthernetClient clients[8];
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   // initialize the Ethernet device
   Ethernet.begin(mac, ip, myDns, gateway, subnet);

--- a/examples/BarometricPressureWebServer/BarometricPressureWebServer.ino
+++ b/examples/BarometricPressureWebServer/BarometricPressureWebServer.ino
@@ -60,11 +60,11 @@ long lastReadingTime = 0;
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   // start the SPI library:
   SPI.begin();
@@ -92,7 +92,7 @@ void setup() {
   // start listening for clients
   server.begin();
 
-  // initalize the data ready and chip select pins:
+  // initialize the data ready and chip select pins:
   pinMode(dataReadyPin, INPUT);
   pinMode(chipSelectPin, OUTPUT);
 
@@ -104,7 +104,7 @@ void setup() {
   // give the sensor and Ethernet shield time to set up:
   delay(1000);
 
-  //Set the sensor to high resolution mode tp start readings:
+  //Set the sensor to high resolution mode to start readings:
   writeRegister(0x03, 0x0A);
 
 }
@@ -131,7 +131,7 @@ void getData() {
   //Read the temperature data
   int tempData = readRegister(0x21, 2);
 
-  // convert the temperature to celsius and display it:
+  // convert the temperature to Celsius and display it:
   temperature = (float)tempData / 20.0;
 
   //Read the pressure data highest 3 bits:
@@ -155,16 +155,16 @@ void listenForEthernetClients() {
   EthernetClient client = server.available();
   if (client) {
     Serial.println("Got a client");
-    // an http request ends with a blank line
+    // an HTTP request ends with a blank line
     bool currentLineIsBlank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();
         // if you've gotten to the end of the line (received a newline
-        // character) and the line is blank, the http request has ended,
+        // character) and the line is blank, the HTTP request has ended,
         // so you can send a reply
         if (c == '\n' && currentLineIsBlank) {
-          // send a standard http response header
+          // send a standard HTTP response header
           client.println("HTTP/1.1 200 OK");
           client.println("Content-Type: text/html");
           client.println();

--- a/examples/ChatServer/ChatServer.ino
+++ b/examples/ChatServer/ChatServer.ino
@@ -4,7 +4,7 @@
  A simple server that distributes any incoming messages to all
  connected clients.  To use, telnet to your device's IP address and type.
  You can see the client's input in the serial monitor as well.
- Using an Arduino Wiznet Ethernet shield.
+ Using an Arduino WIZnet Ethernet shield.
 
  Circuit:
  * Ethernet shield attached to pins 10, 11, 12, 13
@@ -37,13 +37,13 @@ bool alreadyConnected = false; // whether or not the client was connected previo
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
-  // initialize the ethernet device
+  // initialize the Ethernet device
   Ethernet.begin(mac, ip, myDns, gateway, subnet);
 
   // Open serial communications and wait for port to open:
@@ -94,6 +94,3 @@ void loop() {
     }
   }
 }
-
-
-

--- a/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
+++ b/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
@@ -3,7 +3,7 @@
 
   This sketch uses the DHCP extensions to the Ethernet library
   to get an IP address via DHCP and print the address obtained.
-  using an Arduino Wiznet Ethernet shield.
+  using an Arduino WIZnet Ethernet shield.
 
   Circuit:
    Ethernet shield attached to pins 10, 11, 12, 13
@@ -28,11 +28,11 @@ byte mac[] = {
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   // Open serial communications and wait for port to open:
   Serial.begin(9600);
@@ -92,4 +92,3 @@ void loop() {
       break;
   }
 }
-

--- a/examples/DhcpChatServer/DhcpChatServer.ino
+++ b/examples/DhcpChatServer/DhcpChatServer.ino
@@ -4,7 +4,7 @@
  A simple server that distributes any incoming messages to all
  connected clients.  To use, telnet to your device's IP address and type.
  You can see the client's input in the serial monitor as well.
- Using an Arduino Wiznet Ethernet shield.
+ Using an Arduino WIZnet Ethernet shield.
 
  THis version attempts to get an IP address using DHCP
 
@@ -41,11 +41,11 @@ bool gotAMessage = false; // whether or not you got a message from the client ye
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   // Open serial communications and wait for port to open:
   Serial.begin(9600);
@@ -99,4 +99,3 @@ void loop() {
     Ethernet.maintain();
   }
 }
-

--- a/examples/LinkStatus/LinkStatus.ino
+++ b/examples/LinkStatus/LinkStatus.ino
@@ -1,11 +1,11 @@
 /*
   Link Status
-  This sketch prints the ethernet link status. When the
-  ethernet cable is connected the link status should go to "ON".
-  NOTE: Only WizNet W5200 and W5500 are capable of reporting
+  This sketch prints the Ethernet link status. When the
+  Ethernet cable is connected the link status should go to "ON".
+  NOTE: Only WIZnet W5200 and W5500 are capable of reporting
   the link status. W5100 will report "Unknown".
   Hardware:
-   - Ethernet shield or equivalent board/shield with WizNet 5200/5500
+   - Ethernet shield or equivalent board/shield with WIZnet W5200/W5500
   Written by Cristian Maglie
   This example is public domain.
 */
@@ -16,11 +16,11 @@
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   Serial.begin(9600);
 }

--- a/examples/TelnetClient/TelnetClient.ino
+++ b/examples/TelnetClient/TelnetClient.ino
@@ -1,10 +1,10 @@
 /*
   Telnet client
 
- This sketch connects to a a telnet server (http://www.google.com)
- using an Arduino Wiznet Ethernet shield.  You'll need a telnet server
+ This sketch connects to a telnet server (http://www.google.com)
+ using an Arduino WIZnet Ethernet shield.  You'll need a telnet server
  to test this with.
- Processing's ChatServer example (part of the network library) works well,
+ Processing's ChatServer example (part of the Network library) works well,
  running on port 10002. It can be found as part of the examples
  in the Processing application, available at
  http://processing.org/
@@ -39,11 +39,11 @@ EthernetClient client;
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   // start the Ethernet connection:
   Ethernet.begin(mac, ip);
@@ -107,7 +107,3 @@ void loop() {
     }
   }
 }
-
-
-
-

--- a/examples/UDPSendReceiveString/UDPSendReceiveString.ino
+++ b/examples/UDPSendReceiveString/UDPSendReceiveString.ino
@@ -4,7 +4,7 @@
  and sends an "acknowledge" string back to the sender
 
  A Processing sketch is included at the end of file that can be used to send
- and received messages for testing with a computer.
+ and receive messages for testing with a computer.
 
  created 21 Aug 2010
  by Michael Margolis
@@ -35,11 +35,11 @@ EthernetUDP Udp;
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   // start the Ethernet
   Ethernet.begin(mac, ip);
@@ -135,5 +135,3 @@ void loop() {
  println();
  }
  */
-
-

--- a/examples/UdpNtpClient/UdpNtpClient.ino
+++ b/examples/UdpNtpClient/UdpNtpClient.ino
@@ -42,11 +42,11 @@ EthernetUDP Udp;
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   // Open serial communications and wait for port to open:
   Serial.begin(9600);
@@ -144,13 +144,3 @@ void sendNTPpacket(const char * address) {
   Udp.write(packetBuffer, NTP_PACKET_SIZE);
   Udp.endPacket();
 }
-
-
-
-
-
-
-
-
-
-

--- a/examples/WebClient/WebClient.ino
+++ b/examples/WebClient/WebClient.ino
@@ -2,7 +2,7 @@
   Web client
 
  This sketch connects to a website (http://www.google.com)
- using an Arduino Wiznet Ethernet shield.
+ using an Arduino WIZnet Ethernet shield.
 
  Circuit:
  * Ethernet shield attached to pins 10, 11, 12, 13
@@ -43,11 +43,11 @@ bool printWebData = true;  // set to false for better speed measurement
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   // Open serial communications and wait for port to open:
   Serial.begin(9600);
@@ -69,7 +69,7 @@ void setup() {
     if (Ethernet.linkStatus() == LinkOFF) {
       Serial.println("Ethernet cable is not connected.");
     }
-    // try to congifure using IP address instead of DHCP:
+    // try to configure using IP address instead of DHCP:
     Ethernet.begin(mac, ip, myDns);
   } else {
     Serial.print("  DHCP assigned IP ");
@@ -134,4 +134,3 @@ void loop() {
     }
   }
 }
-

--- a/examples/WebClientRepeating/WebClientRepeating.ino
+++ b/examples/WebClientRepeating/WebClientRepeating.ino
@@ -2,9 +2,9 @@
   Repeating Web client
 
  This sketch connects to a a web server and makes a request
- using a Wiznet Ethernet shield. You can use the Arduino Ethernet shield, or
+ using a WIZnet Ethernet shield. You can use the Arduino Ethernet Shield, or
  the Adafruit Ethernet shield, either one will work, as long as it's got
- a Wiznet Ethernet module on board.
+ a WIZnet Ethernet module on board.
 
  This example uses DNS, by assigning the Ethernet client with a MAC address,
  IP address, and DNS address.
@@ -25,7 +25,7 @@
 #include <SPI.h>
 #include <Ethernet.h>
 
-// assign a MAC address for the ethernet controller.
+// assign a MAC address for the Ethernet controller.
 // fill in your address here:
 byte mac[] = {
   0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
@@ -46,11 +46,11 @@ const unsigned long postingInterval = 10*1000;  // delay between updates, in mil
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   // start serial port:
   Serial.begin(9600);
@@ -72,7 +72,7 @@ void setup() {
     if (Ethernet.linkStatus() == LinkOFF) {
       Serial.println("Ethernet cable is not connected.");
     }
-    // try to congifure using IP address instead of DHCP:
+    // try to configure using IP address instead of DHCP:
     Ethernet.begin(mac, ip, myDns);
     Serial.print("My IP address: ");
     Serial.println(Ethernet.localIP());
@@ -124,7 +124,3 @@ void httpRequest() {
     Serial.println("connection failed");
   }
 }
-
-
-
-

--- a/examples/WebServer/WebServer.ino
+++ b/examples/WebServer/WebServer.ino
@@ -2,7 +2,7 @@
   Web Server
 
  A simple web server that shows the value of the analog input pins.
- using an Arduino Wiznet Ethernet shield.
+ using an Arduino WIZnet Ethernet shield.
 
  Circuit:
  * Ethernet shield attached to pins 10, 11, 12, 13
@@ -35,11 +35,11 @@ EthernetServer server(80);
 void setup() {
   // You can use Ethernet.init(pin) to configure the CS pin
   //Ethernet.init(10);  // Most Arduino shields
-  //Ethernet.init(5);   // MKR ETH shield
+  //Ethernet.init(5);   // MKR ETH Shield
   //Ethernet.init(0);   // Teensy 2.0
   //Ethernet.init(20);  // Teensy++ 2.0
-  //Ethernet.init(15);  // ESP8266 with Adafruit Featherwing Ethernet
-  //Ethernet.init(33);  // ESP32 with Adafruit Featherwing Ethernet
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
 
   // Open serial communications and wait for port to open:
   Serial.begin(9600);
@@ -74,17 +74,17 @@ void loop() {
   EthernetClient client = server.available();
   if (client) {
     Serial.println("new client");
-    // an http request ends with a blank line
+    // an HTTP request ends with a blank line
     bool currentLineIsBlank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();
         Serial.write(c);
         // if you've gotten to the end of the line (received a newline
-        // character) and the line is blank, the http request has ended,
+        // character) and the line is blank, the HTTP request has ended,
         // so you can send a reply
         if (c == '\n' && currentLineIsBlank) {
-          // send a standard http response header
+          // send a standard HTTP response header
           client.println("HTTP/1.1 200 OK");
           client.println("Content-Type: text/html");
           client.println("Connection: close");  // the connection will be closed after completion of the response
@@ -120,4 +120,3 @@ void loop() {
     Serial.println("client disconnected");
   }
 }
-

--- a/src/Dns.cpp
+++ b/src/Dns.cpp
@@ -1,4 +1,4 @@
-// Arduino DNS client for WizNet5100-based Ethernet shield
+// Arduino DNS client for WIZnet W5100-based Ethernet shield
 // (c) Copyright 2009-2010 MCQN Ltd.
 // Released under Apache License, version 2.0
 
@@ -336,7 +336,7 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
 				iUdp.flush(); // FIXME
 				return -9;//INVALID_RESPONSE;
 			}
-			// FIXME: seeems to lock up here on ESP8266, but why??
+			// FIXME: seems to lock up here on ESP8266, but why??
 			iUdp.read(aAddress.raw_address(), 4);
 			return SUCCESS;
 		} else {
@@ -351,4 +351,3 @@ uint16_t DNSClient::ProcessResponse(uint16_t aTimeout, IPAddress& aAddress)
 	// If we get here then we haven't found an answer
 	return -10; //INVALID_RESPONSE;
 }
-

--- a/src/Dns.h
+++ b/src/Dns.h
@@ -1,4 +1,4 @@
-// Arduino DNS client for WizNet5100-based Ethernet shield
+// Arduino DNS client for WIZnet W5100-based Ethernet shield
 // (c) Copyright 2009-2010 MCQN Ltd.
 // Released under Apache License, version 2.0
 

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -39,12 +39,12 @@
 #define MAX_SOCK_NUM 8
 #endif
 
-// By default, each socket uses 2K buffers inside the Wiznet chip.  If
+// By default, each socket uses 2K buffers inside the WIZnet chip.  If
 // MAX_SOCK_NUM is set to fewer than the chip's maximum, uncommenting
-// this will use larger buffers within the Wiznet chip.  Large buffers
+// this will use larger buffers within the WIZnet chip.  Large buffers
 // can really help with UDP protocols like Artnet.  In theory larger
 // buffers should allow faster TCP over high-latency links, but this
-// does not always seem to work in practice (maybe Wiznet bugs?)
+// does not always seem to work in practice (maybe WIZnet bugs?)
 //#define ETHERNET_LARGE_BUFFERS
 
 
@@ -84,7 +84,7 @@ public:
 	static EthernetLinkStatus linkStatus();
 	static EthernetHardwareStatus hardwareStatus();
 
-	// Manaul configuration
+	// Manual configuration
 	static void begin(uint8_t *mac, IPAddress ip);
 	static void begin(uint8_t *mac, IPAddress ip, IPAddress dns);
 	static void begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress gateway);

--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -92,12 +92,12 @@ int EthernetClient::available()
 {
 	if (sockindex >= MAX_SOCK_NUM) return 0;
 	return Ethernet.socketRecvAvailable(sockindex);
-	// TODO: do the Wiznet chips automatically retransmit TCP ACK
+	// TODO: do the WIZnet chips automatically retransmit TCP ACK
 	// packets if they are lost by the network?  Someday this should
 	// be checked by a man-in-the-middle test which discards certain
 	// packets.  If ACKs aren't resent, we would need to check for
 	// returning 0 here and after a timeout do another Sock_RECV
-	// command to cause the Wiznet chip to resend the ACK packet.
+	// command to cause the WIZnet chip to resend the ACK packet.
 }
 
 int EthernetClient::read(uint8_t *buf, size_t size)
@@ -211,5 +211,3 @@ uint16_t EthernetClient::remotePort()
 	SPI.endTransaction();
 	return port;
 }
-
-

--- a/src/EthernetUdp.cpp
+++ b/src/EthernetUdp.cpp
@@ -1,5 +1,5 @@
 /*
- *  Udp.cpp: Library to send/receive UDP packets with the Arduino ethernet shield.
+ *  Udp.cpp: Library to send/receive UDP packets with the Arduino Ethernet Shield.
  *  This version only offers minimal wrapping of socket.cpp
  *  Drop Udp.h/.cpp into the Ethernet library directory at hardware/libraries/Ethernet/
  *
@@ -188,4 +188,3 @@ uint8_t EthernetUDP::beginMulticast(IPAddress ip, uint16_t port)
 	_remaining = 0;
 	return 1;
 }
-

--- a/src/EthernetUdp.h
+++ b/src/EthernetUdp.h
@@ -1,5 +1,5 @@
 /*
- *  Udp.cpp: Library to send/receive UDP packets with the Arduino ethernet shield.
+ *  Udp.cpp: Library to send/receive UDP packets with the Arduino Ethernet Shield.
  *  This version only offers minimal wrapping of socket.cpp
  *  Drop Udp.h/.cpp into the Ethernet library directory at hardware/libraries/Ethernet/
  *

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -536,4 +536,3 @@ bool EthernetClass::socketSendUDP(uint8_t s)
 	/* Sent ok */
 	return true;
 }
-

--- a/src/utility/w5100.cpp
+++ b/src/utility/w5100.cpp
@@ -18,7 +18,7 @@
 /***************************************************/
 
 // If variant.h or other headers specifically define the
-// default SS pin for ethernet, use it.
+// default SS pin for Ethernet, use it.
 #if defined(PIN_SPI_SS_ETHERNET_LIB)
 #define SS_PIN_DEFAULT  PIN_SPI_SS_ETHERNET_LIB
 
@@ -132,7 +132,7 @@ uint8_t W5100Class::init(void)
 			writeSnRX_SIZE(i, 0);
 			writeSnTX_SIZE(i, 0);
 		}
-	// Try W5500 next.  Wiznet finally seems to have implemented
+	// Try W5500 next.  WIZnet finally seems to have implemented
 	// SPI well with this chip.  It appears to be very resilient,
 	// so try it after the fragile W5200
 	} else if (isW5500()) {
@@ -197,12 +197,12 @@ uint8_t W5100Class::init(void)
 	return 1; // successful init
 }
 
-// Soft reset the Wiznet chip, by writing to its MR register reset bit
+// Soft reset the WIZnet chip, by writing to its MR register reset bit
 uint8_t W5100Class::softReset(void)
 {
 	uint16_t count=0;
 
-	//Serial.println("Wiznet soft reset");
+	//Serial.println("WIZnet soft reset");
 	// write to reset bit
 	writeMR(0x80);
 	// then wait for soft reset to complete


### PR DESCRIPTION
This PR provides the standardized [GitHub Actions](https://github.com/features/actions)-based CI configuration for Arduino libraries.

### Dependabot

Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to be outdated, it will submit a pull request to update them.

NOTE: Dependabot's PRs will sometimes try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump. So even if the PRs from Dependabot are not always exactly correct, their value lies in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.

More information:
https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

### Spell check

On every push, pull request, and periodically, use [the `codespell-project/actions-codespell` action](https://github.com/codespell-project/actions-codespell) to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.

### Arduino Lint

On every push, pull request, and periodically, run [Arduino Lint](https://github.com/arduino/arduino-lint) to check for common problems not related to the project code.

### Compile examples

On every push or pull request that affects library source or example files, and periodically, use [the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) to compile all example sketches for the specified boards.

### Report size deltas

On creation or commit to a pull request, use [the `arduino/report-size-deltas` action](https://github.com/arduino/report-size-deltas) to comment a report of the resulting change in memory usage of the examples to the PR thread.

---
Fixes https://github.com/arduino-libraries/Ethernet/issues/154