### PR TITLE
Allow for an explicit change of SPI speed

### DIFF
--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -17,6 +17,11 @@
 #include <Arduino.h>
 #include <SPI.h>
 
+// add SPI_ETHERNET_SPEED to allow for an explicit change of SPI speed
+#ifndef SPI_ETHERNET_SPEED
+#define SPI_ETHERNET_SPEED 14000000
+#endif
+
 // Safe for all chips
 #define SPI_ETHERNET_SETTINGS SPISettings(14000000, MSBFIRST, SPI_MODE0)
 

--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -23,7 +23,7 @@
 #endif
 
 // Safe for all chips
-#define SPI_ETHERNET_SETTINGS SPISettings(14000000, MSBFIRST, SPI_MODE0)
+#define SPI_ETHERNET_SETTINGS SPISettings(SPI_ETHERNET_SPEED, MSBFIRST, SPI_MODE0)
 
 // Safe for W5200 and W5500, but too fast for W5100
 // Uncomment this if you know you'll never need W5100 support.


### PR DESCRIPTION
I am using Ethernet chips like W5*00 a lot in an industrial applications, where the galvanic isolation of the controller is essential. Sometimes the isolation driver can only go 1Mbps fast (e.g. adum1401), which makes it impossible to connect W5x00 to the Atmega chip. Suggested minor change allows for explicit selection of the SPI speed with #define SPI_ETHERNET_SPEED directive.

---

Partially resolves [#<!---->267](https://github.com/arduino-libraries/Ethernet/issues/267)