### PR TITLE
Fix compiler warning in `htons()`

### DIFF
--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -455,14 +455,23 @@ extern W5100Class W5100;
 #define UTIL_H
 
 #ifndef htons
+// The host order of the Arduino platform is little endian.
+// Sometimes it is desired to convert to big endian (or
+// network order)
 
-#define htons(x) ( (((x)<<8)&0xFF00) | (((x)>>8)&0xFF) )
+// Host to Network short
+#define htons(x) ( (((x)&0xFF)<<8) | (((x)>>8)&0xFF) )
+
+// Network to Host short
 #define ntohs(x) htons(x)
 
+// Host to Network long
 #define htonl(x) ( ((x)<<24 & 0xFF000000UL) | \
                    ((x)<< 8 & 0x00FF0000UL) | \
                    ((x)>> 8 & 0x0000FF00UL) | \
                    ((x)>>24 & 0x000000FFUL) )
+
+// Network to Host long
 #define ntohl(x) htonl(x)
 
 #endif // !defined(htons)


### PR DESCRIPTION
Fixes #151
Fixes #122 

~~The macros are completely redundant. Using for example `htons()` on a `uint16_t` just wastes cycles if the compiler doesn't optimise it out. `htons()` converts a variable to 16 bits (which does nothing for a 16 bit variable). Same goes for `htonl()` for 32-bit variables.~~

~~Building these changes in a project of mine shows the memory footprint is reduced by **32 bytes**. This will also fix two issues related to overflow compiler warnings with `htons()`.~~

Edit: This PR will only fix the compiler warning in the linked issues.