### PR TITLE
Add compatibility with Portenta H7

### DIFF
--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -47,6 +47,9 @@
 // does not always seem to work in practice (maybe WIZnet bugs?)
 //#define ETHERNET_LARGE_BUFFERS
 
+#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4)
+#include <PortentaEthernet.h>
+#endif
 
 #include <Arduino.h>
 #include "Client.h"


### PR DESCRIPTION
As discussed with @facchinm one additional include is required to make this library compatible with Portenta H7.
This is required when using the MKR ETH shield with the Portenta H7.
This has not been tested yet.