### PR TITLE
Fixing CI build for Arduino SAM Due.

### DIFF
--- a/examples/PagerServer/PagerServer.ino
+++ b/examples/PagerServer/PagerServer.ino
@@ -64,6 +64,8 @@ void loop() {
     Serial.println(s); // print the message to Serial Monitor
     client.print("echo: "); // this is only for the sending client
     server.println(s); // send the message to all connected clients
+#ifndef ARDUINO_ARCH_SAM
     server.flush(); // flush the buffers
+#endif /* !defined(ARDUINO_ARCH_SAM) */
   }
 }


### PR DESCRIPTION
The class EthernetServer, derived from Server, derived from Print does not contain a 'flush' method as for all other cores.