### PR TITLE
Fix erroneous return value of EthernetClient::write()

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -83,9 +83,9 @@ size_t EthernetClient::write(uint8_t b)
 size_t EthernetClient::write(const uint8_t *buf, size_t size)
 {
 	if (_sockindex >= MAX_SOCK_NUM) return 0;
-	if (Ethernet.socketSend(_sockindex, buf, size)) return size;
-	setWriteError();
-	return 0;
+	const size_t bytesSent = Ethernet.socketSend(_sockindex, buf, size);
+	if (!bytesSent)	setWriteError();
+	return bytesSent;
 }
 
 int EthernetClient::available()

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -417,7 +417,7 @@ static void write_data(uint8_t s, uint16_t data_offset, const uint8_t *data, uin
 
 /**
  * @brief	This function used to send the data in TCP mode
- * @return	1 for success else 0.
+ * @return	number of bytes sent for success 0 in case of error.
  */
 uint16_t EthernetClass::socketSend(uint8_t s, const uint8_t * buf, uint16_t len)
 {


### PR DESCRIPTION
Fix the issue that the method always returned the incoming size
parameter regardless of how many bytes were actually sent by
EthernetClass::socketSend(). The return value was always wrong if the
data size was bigger than the socket buffer size.