### PR TITLE
Set socket to invalid socket if connection fails

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -60,7 +60,7 @@ int EthernetClient::connect(IPAddress ip, uint16_t port)
 		uint8_t stat = Ethernet.socketStatus(_sockindex);
 		if (stat == SnSR::ESTABLISHED) return 1;
 		if (stat == SnSR::CLOSE_WAIT) return 1;
-		if (stat == SnSR::CLOSED) return 0;
+		if (stat == SnSR::CLOSED) break;
 		if (millis() - start > _timeout) break;
 		delay(1);
 	}


### PR DESCRIPTION
I've been experiencing a bug using the Arduino to communicate over ethernet when using multiple EthernetClients, and as far as I can tell this line is the culprit. The exact steps of how the bug happens:
- Initialize two EthernetClients A and B to talk to HOST at PORT1 and PORT2
- `A.connect(HOST, PORT1);` is called first. Inside the `connect` function, the function `socketBegin` is called, which according to the code [here](https://github.com/arduino-libraries/Ethernet/blob/9e8a98cd745ee4b4e033819bcc38721fb15ab1b7/src/socket.cpp#L82) finds the first unused socket number and returns it. Lets say in this case the first unused socket number is 0. This means that `A._socketIndex` ends up being 0.
- For some reason, `A.connect(HOST, PORT1);` fails on line 63. However, note that `A._socketIndex` is NOT reset back to `MAX_SOCK_NUM` and stays at the initialized value (for this example we'll stick with 0).
- `B.connect(HOST, PORT2);` is called second. The process as above happens, and `B._socketIndex` is set to 0. However, for some reason `B.connect(HOST, PORT2);` works, and B is able to connect.
- Note that now `B._socketIndex == A._socketIndex == 0`. However, since `A.connect(HOST, PORT1)` returned 0 (which stands for false), calls to `A.available()`, `A.read()` shouldn't work. Instead, they _do_ work, and even worse `A.write()` will write data to *the socket that B is connected to*.

This change should fix the bug, because instead of returning 0 on line 63 we break, we set _socketIndex back to MAX_SOCK_NUM and everything behaves as expected.