### PR TITLE
Allow redefining ETHERNET_MAX_SOCK_NUM, ETHERNET_SPI_SPEED

### DIFF
--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -33,7 +33,9 @@
 // up to 4 sockets.  W5200 & W5500 can have up to 8 sockets.  Several bytes
 // of RAM are used for each socket.  Reducing the maximum can save RAM, but
 // you are limited to fewer simultaneous connections.
-#if defined(RAMEND) && defined(RAMSTART) && ((RAMEND - RAMSTART) <= 2048)
+#if defined(ETHERNET_MAX_SOCK_NUM)
+#define MAX_SOCK_NUM ETHERNET_MAX_SOCK_NUM
+#elif defined(RAMEND) && defined(RAMSTART) && ((RAMEND - RAMSTART) <= 2048)
 #define MAX_SOCK_NUM 4
 #else
 #define MAX_SOCK_NUM 8

--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -17,37 +17,27 @@
 #include <Arduino.h>
 #include <SPI.h>
 
-// Safe for all chips
-#define SPI_ETHERNET_SETTINGS SPISettings(14000000, MSBFIRST, SPI_MODE0)
+#if defined(ETHERNET_SPI_SPEED)
+  // Good! Using the configured value.
+#elif defined(ARDUINO_ARCH_ARC32)
+  // Arduino 101's SPI can not run faster than 8 MHz.
+  #define ETHERNET_SPI_SPEED 8000000
+#elif defined(__SAMD21G18A__)
+  // Arduino Zero can't use W5100-based shields faster than 8 MHz
+  // https://github.com/arduino-libraries/Ethernet/issues/37#issuecomment-408036848
+  // W5500 does seem to work at 12 MHz.  Delete this if only using W5500
+  #define ETHERNET_SPI_SPEED 8000000
+#else
+  // Default. Safe for all chips.
+  #define ETHERNET_SPI_SPEED 14000000
+#endif
 
-// Safe for W5200 and W5500, but too fast for W5100
-// Uncomment this if you know you'll never need W5100 support.
-//  Higher SPI clock only results in faster transfer to hosts on a LAN
-//  or with very low packet latency.  With ordinary internet latency,
-//  the TCP window size & packet loss determine your overall speed.
-//#define SPI_ETHERNET_SETTINGS SPISettings(30000000, MSBFIRST, SPI_MODE0)
-
+#define SPI_ETHERNET_SETTINGS SPISettings(ETHERNET_SPI_SPEED, MSBFIRST, SPI_MODE0)
 
 // Require Ethernet.h, because we need MAX_SOCK_NUM
 #ifndef ethernet_h_
 #error "Ethernet.h must be included before w5100.h"
 #endif
-
-
-// Arduino 101's SPI can not run faster than 8 MHz.
-#if defined(ARDUINO_ARCH_ARC32)
-#undef SPI_ETHERNET_SETTINGS
-#define SPI_ETHERNET_SETTINGS SPISettings(8000000, MSBFIRST, SPI_MODE0)
-#endif
-
-// Arduino Zero can't use W5100-based shields faster than 8 MHz
-// https://github.com/arduino-libraries/Ethernet/issues/37#issuecomment-408036848
-// W5500 does seem to work at 12 MHz.  Delete this if only using W5500
-#if defined(__SAMD21G18A__)
-#undef SPI_ETHERNET_SETTINGS
-#define SPI_ETHERNET_SETTINGS SPISettings(8000000, MSBFIRST, SPI_MODE0)
-#endif
-
 
 typedef uint8_t SOCKET;
 


### PR DESCRIPTION
`MAX_SOCK_NUM` and `SPI_ETHERNET_SETTINGS` are currently hard-coded, but there are many cases where one would like to override this. Currently, this requires patching the library.

This PR adds 2 preprocessor definitions: `ETHERNET_MAX_SOCK_NUM`, `ETHERNET_SPI_SPEED` which can be easily overridden by the build system (like PlatformIO).
Another related setting, `ETHERNET_LARGE_BUFFERS` is already configurable externally.

I.e. I was able to get 3.4 MBps download speed on ESP32 by applying the PIO configuration:
```ini
build_flags =
    -DETHERNET_SPI_SPEED=64000000
    -DETHERNET_MAX_SOCK_NUM=2
    -DETHERNET_LARGE_BUFFERS
```
