### PR TITLE
Fixes static IPs for Arduino Nano Every

### DIFF
--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -83,19 +83,9 @@ void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress g
 	if (W5100.init() == 0) return;
 	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac);
-#ifdef ESP8266
-	W5100.setIPAddress(&ip[0]);
-	W5100.setGatewayIp(&gateway[0]);
-	W5100.setSubnetMask(&subnet[0]);
-#elif ARDUINO > 106 || TEENSYDUINO > 121
-	W5100.setIPAddress(ip._address.bytes);
-	W5100.setGatewayIp(gateway._address.bytes);
-	W5100.setSubnetMask(subnet._address.bytes);
-#else
-	W5100.setIPAddress(ip._address);
-	W5100.setGatewayIp(gateway._address);
-	W5100.setSubnetMask(subnet._address);
-#endif
+	W5100.setIPAddress(ip.raw_address());
+	W5100.setGatewayIp(gateway.raw_address());
+	W5100.setSubnetMask(subnet.raw_address());
 	SPI.endTransaction();
 	_dnsServerAddress = dns;
 }


### PR DESCRIPTION
The example program WebClient does not work on the Arduino Nano Every when DHCP is not available or commented out - the versions of Ethernet::begin() using a static IP address fail.  I tested the example on Uno, Mega2560 and Micro, it works on all of them using either DHCP or static IP.

This modifies the begin() method so that it uses IPAddress::raw_address() instead of platform conditional code in the same way the DHCP version of begin() does. With this change static addresses work on the Nano Every too.