### PR TITLE
Create option for setting and getting the hostname

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -473,6 +473,83 @@ void setup() {
 void loop () {}
 ```
 
+### `Ethernet.setHostName()`
+
+#### Description
+
+Set the hostname of the device. This is used in DHCP requests and responses.
+
+
+#### Syntax
+
+```
+Ethernet.setHostName(hostName)
+
+```
+
+#### Parameters
+- hostName: the hostname of the device (const char*)
+
+#### Returns
+Nothing
+
+#### Example
+
+```
+#include <SPI.h>
+#include <Ethernet.h>
+
+byte mac[] = {0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED};
+char hostName[] = "NameOfTheDevice";
+
+void setup() {
+  Ethernet.setHostName(hostName);
+  Ethernet.begin(mac);
+}
+
+void loop () {}
+```
+
+### `Ethernet.getHostName()`
+
+#### Description
+
+Get the hostname of the device. This is used in DHCP requests and responses.
+
+
+#### Syntax
+
+```
+Ethernet.getHostName()
+
+```
+
+#### Parameters
+none
+
+#### Returns
+- hostName: the hostname of the device (const char*)
+
+#### Example
+
+```
+#include <SPI.h>
+#include <Ethernet.h>
+
+byte mac[] = {0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED};
+
+void setup() {
+  Ethernet.begin(mac);
+  const char* hostName = Ethernet.getHostName();
+
+  Serial.begin(9600);
+  Serial.print("Host name: ");
+  Serial.println(hostName);
+}
+
+void loop () {}
+```
+
 ### `Ethernet.setGatewayIP()`
 
 #### Description

--- a/examples/SetHostName/SetHostName.ino
+++ b/examples/SetHostName/SetHostName.ino
@@ -1,0 +1,61 @@
+/*
+  Set Host Name
+
+  This example shows you how to set the host name with the Ethernet library.
+
+  Circuit:
+  * Ethernet shield attached to pins 10, 11, 12, 13
+
+  created 28 May 2023
+  by Attila Herczog
+*/
+
+#include <SPI.h>
+#include <Ethernet.h>
+
+// Enter a MAC address for your controller below.
+// Newer Ethernet shields have a MAC address printed on a sticker on the shield
+byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
+
+// Host name to use
+char hostName[] = "ExampleHostName";
+
+void setup()
+{
+  // Open serial communications and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial)
+  {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+  Serial.println("Host Name Example");
+
+  // Set the Host Name
+  // Call this function before Ethernet.begin() to set your host name.
+  Ethernet.setHostName(hostName);
+
+  // Start the Ethernet connection and the server:
+  Ethernet.begin(mac);
+
+  // Check for Ethernet hardware present
+  if (Ethernet.hardwareStatus() == EthernetNoHardware)
+  {
+    Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
+    while (true)
+    {
+      delay(1); // do nothing, no point running without Ethernet hardware
+    }
+  }
+  if (Ethernet.linkStatus() == LinkOFF)
+  {
+    Serial.println("Ethernet cable is not connected.");
+  }
+
+  Serial.print("My IP is: ");
+  Serial.println(Ethernet.localIP());
+  Serial.print("My host name is: ");
+  Serial.println(Ethernet.getHostName());
+  Serial.println("You can now check your router's DHCP table to see the assigned host name.");
+}
+
+void loop() {}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Ethernet
-version=2.0.3
+version=2.0.2
 author=Various (see AUTHORS file for details)
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables network connection (local and Internet) using the Arduino Ethernet Board or Shield.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Ethernet
-version=2.0.2
+version=2.0.3
 author=Various (see AUTHORS file for details)
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables network connection (local and Internet) using the Arduino Ethernet Board or Shield.

--- a/src/Dhcp.h
+++ b/src/Dhcp.h
@@ -42,7 +42,6 @@
 #define MAGIC_COOKIE		0x63825363
 #define MAX_DHCP_OPT		16
 
-#define HOST_NAME "WIZnet"
 #define DEFAULT_LEASE	(900) //default lease time in seconds
 
 #define DHCP_CHECK_NONE         (0)

--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -232,17 +232,8 @@ void EthernetClass::setRetransmissionCount(uint8_t num)
 }
 
 void EthernetClass::generateDefaultHostName(uint8_t *mac) {
-	// Copy the default host name base
-	strcpy(_hostName, DEFAULT_HOST_NAME);
-
-	// Append the last 3 bytes of the MAC (HEX'd)
-    char macAddrStr[3];
-    sprintf(macAddrStr, "%02X", mac[3]);
-    strcat(_hostName, macAddrStr);
-    sprintf(macAddrStr, "%02X", mac[4]);
-    strcat(_hostName, macAddrStr);
-    sprintf(macAddrStr, "%02X", mac[5]);
-    strcat(_hostName, macAddrStr);
+	// Generate a default host name based on the MAC address
+	sprintf_P(_hostName, PSTR("%s%02X%02X%02X"), DEFAULT_HOST_NAME, mac[3], mac[4], mac[5]);
 }
 
 void EthernetClass::setHostName(const char *dhcpHost) {

--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -233,7 +233,16 @@ void EthernetClass::setRetransmissionCount(uint8_t num)
 
 void EthernetClass::generateDefaultHostName(uint8_t *mac) {
 	// Generate a default host name based on the MAC address
-	sprintf_P(_hostName, PSTR("%s%02X%02X%02X"), DEFAULT_HOST_NAME, mac[3], mac[4], mac[5]);
+	strcpy_P(_hostName, PSTR(DEFAULT_HOST_NAME));
+	
+	// Append last 3 bytes of MAC address to the name
+	PGM_P hexChars = PSTR("0123456789ABCDEF");
+	for (int i = 0; i <= 2; i++)
+	{
+		_hostName[DEFAULT_HOST_NAME_LENGTH + i * 2] = pgm_read_byte_near(hexChars + (mac[3 + i] >> 4));
+		_hostName[DEFAULT_HOST_NAME_LENGTH + i * 2 + 1] = pgm_read_byte_near(hexChars + (mac[3 + i] & 0x0F));
+	}
+	_hostName[DEFAULT_HOST_NAME_LENGTH + 6] = '\0';
 }
 
 void EthernetClass::setHostName(const char *dhcpHost) {

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -54,6 +54,7 @@
 #include "Udp.h"
 
 #define DEFAULT_HOST_NAME "WIZnet"
+#define DEFAULT_HOST_NAME_LENGTH (sizeof(DEFAULT_HOST_NAME) - 1)
 #define HOST_NAME_MAX_LEN 20 // Max 30 or change the DHCP local buffer size
 
 enum EthernetLinkStatus {

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -53,6 +53,9 @@
 #include "Server.h"
 #include "Udp.h"
 
+#define DEFAULT_HOST_NAME "WIZnet"
+#define HOST_NAME_MAX_LEN 20 // Max 30 or change the DHCP local buffer size
+
 enum EthernetLinkStatus {
 	Unknown,
 	LinkON,
@@ -75,6 +78,8 @@ class EthernetClass {
 private:
 	static IPAddress _dnsServerAddress;
 	static DhcpClass* _dhcp;
+	static char _hostName[HOST_NAME_MAX_LEN];
+	static bool _manualHostName;
 public:
 	// Initialise the Ethernet shield to use the provided MAC address and
 	// gain the rest of the configuration through DHCP.
@@ -104,6 +109,8 @@ public:
 	void setDnsServerIP(const IPAddress dns_server) { _dnsServerAddress = dns_server; }
 	void setRetransmissionTimeout(uint16_t milliseconds);
 	void setRetransmissionCount(uint8_t num);
+  	void setHostName(const char *hostName);
+	char* getHostName();
 
 	friend class EthernetClient;
 	friend class EthernetServer;
@@ -142,6 +149,7 @@ private:
 	static bool socketSendUDP(uint8_t s);
 	// Initialize the "random" source port number
 	static void socketPortRand(uint16_t n);
+	static void generateDefaultHostName(uint8_t *mac);
 };
 
 extern EthernetClass Ethernet;
@@ -275,6 +283,7 @@ private:
 	uint32_t _dhcpInitialTransactionId;
 	uint32_t _dhcpTransactionId;
 	uint8_t  _dhcpMacAddr[6];
+	const char* _dhcpHostName;
 #ifdef __arm__
 	uint8_t  _dhcpLocalIp[4] __attribute__((aligned(4)));
 	uint8_t  _dhcpSubnetMask[4] __attribute__((aligned(4)));
@@ -312,7 +321,7 @@ public:
 	IPAddress getDhcpServerIp();
 	IPAddress getDnsServerIp();
 
-	int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
+	int beginWithDHCP(uint8_t *, const char *hostName, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
 	int checkLease();
 };
 


### PR DESCRIPTION
I implemented a way to set the hostname manually.

I know, there are two similar PRs on this topic:
https://github.com/arduino-libraries/Ethernet/pull/50
https://github.com/arduino/Arduino/pull/5701

These are pretty old requests and I haven't seen any valuable updates in the last few years.

I collected all problems and reviews in the other codes and created a solution that fixes the already-mentioned problems.
With this update, you can call `Ethernet.setHostName();` and `Ethernet.getHostName();`. If you don't call the setter, the automatically generated hostname will be used, like before. If you call the setter with any text, that will be used and the MAC won't be concatenated.

I tried to do my best at the implementation and documentation, but please review this request and let me know, if something needs to be changed.