### PR TITLE
Ethernet.setHostname added (hostname to send with DHCP request)

### DIFF
--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -188,6 +188,8 @@ void DhcpClass::send_DHCP_MESSAGE(uint8_t messageType, uint16_t secondsElapsed)
 
 	// OPT - host name
 	buffer[16] = hostName;
+
+	if (_hostname == nullptr) {
 	buffer[17] = strlen(HOST_NAME) + 6; // length of hostname + last 3 bytes of mac address
 	strcpy((char*)&(buffer[18]), HOST_NAME);
 
@@ -197,6 +199,12 @@ void DhcpClass::send_DHCP_MESSAGE(uint8_t messageType, uint16_t secondsElapsed)
 
 	//put data in W5100 transmit buffer
 	_dhcpUdpSocket.write(buffer, 30);
+	} else {
+		uint8_t len = strlen(_hostname);
+		buffer[17] = len;
+		_dhcpUdpSocket.write(buffer, 18);
+		_dhcpUdpSocket.write(_hostname, len);
+	}
 
 	if (messageType == DHCP_REQUEST) {
 		buffer[0] = dhcpRequestedIPaddr;
@@ -418,6 +426,11 @@ IPAddress DhcpClass::getDhcpServerIp()
 IPAddress DhcpClass::getDnsServerIp()
 {
 	return IPAddress(_dhcpDnsServerIp);
+}
+
+void DhcpClass::setHostname(const char* hostname)
+{
+	_hostname = hostname;
 }
 
 void DhcpClass::printByte(char * buf, uint8_t n )

--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -28,8 +28,9 @@ DhcpClass* EthernetClass::_dhcp = NULL;
 
 int EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
 {
-	static DhcpClass s_dhcp;
-	_dhcp = &s_dhcp;
+	if (_dhcp == NULL) {
+		_dhcp = new DhcpClass();
+	}
 
 	// Initialise the basic info
 	if (W5100.init() == 0) return 0;
@@ -176,6 +177,14 @@ IPAddress EthernetClass::gatewayIP()
 	W5100.getGatewayIp(ret.raw_address());
 	SPI.endTransaction();
 	return ret;
+}
+
+void EthernetClass::setHostname(const char* hostname)
+{
+	if (_dhcp == NULL) {
+		_dhcp = new DhcpClass();
+	}
+	_dhcp->setHostname(hostname);
 }
 
 void EthernetClass::setMACAddress(const uint8_t *mac_address)

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -97,6 +97,7 @@ public:
 	static IPAddress gatewayIP();
 	static IPAddress dnsServerIP() { return _dnsServerAddress; }
 
+	void setHostname(const char* hostname); // only the pointer is stored!
 	void setMACAddress(const uint8_t *mac_address);
 	void setLocalIP(const IPAddress local_ip);
 	void setSubnetMask(const IPAddress subnet);
@@ -275,6 +276,7 @@ private:
 	uint32_t _dhcpInitialTransactionId;
 	uint32_t _dhcpTransactionId;
 	uint8_t  _dhcpMacAddr[6];
+	const char* _hostname = nullptr;
 #ifdef __arm__
 	uint8_t  _dhcpLocalIp[4] __attribute__((aligned(4)));
 	uint8_t  _dhcpSubnetMask[4] __attribute__((aligned(4)));
@@ -314,6 +316,7 @@ public:
 
 	int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
 	int checkLease();
+	void setHostname(const char* hostname);
 };
 
 


### PR DESCRIPTION
There is already [a PR](https://github.com/arduino-libraries/Ethernet/pull/223) for `setHostname` to set the hostname sent with the DHCP request and some older PR which don't use the setHostname() setter.

I provide my approach which doesn't store the hostname internally to save memory. I added the same code to my EthernetENC library. If setHostname is not used from the sketch the old code with the default hostname is executed.

overview of WiFi/Ethernet getters and setters:
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#network-interface-getters-and-setters