### PR TITLE
EthernetServer - added end(), begin(port) and ctor without parameters

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -884,11 +884,12 @@ Tells the server to begin listening for incoming connections.
 
 ```
 server.begin()
+server.begin(port)
 
 ```
 
 #### Parameters
-None
+- port (optional): the port to listen on (int)
 
 #### Returns
 None

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -255,10 +255,13 @@ class EthernetServer : public Server {
 private:
 	uint16_t _port;
 public:
+	EthernetServer() : _port(80) { }
 	EthernetServer(uint16_t port) : _port(port) { }
 	EthernetClient available();
 	EthernetClient accept();
 	virtual void begin();
+	void begin(uint16_t port);
+	void end(uint16_t timeout = 5000);
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t *buf, size_t size);
 	virtual operator bool();

--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -37,6 +37,43 @@ void EthernetServer::begin()
 	}
 }
 
+void EthernetServer::begin(uint16_t port)
+{
+	end();
+	_port = port;
+	begin();
+}
+
+void EthernetServer::end(uint16_t timeout)
+{
+	for (uint8_t i=0; i < MAX_SOCK_NUM; i++) {
+		if (server_port[i] == _port) {
+			Ethernet.socketDisconnect(i);
+		}
+	}
+	unsigned long start = millis();
+	bool allClosed = false;
+	while (!allClosed && millis() - start < timeout) {
+		allClosed = true;
+		for (uint8_t i=0; i < MAX_SOCK_NUM; i++) {
+			if (server_port[i] == _port) {
+				if (Ethernet.socketStatus(i) == SnSR::CLOSED) {
+					server_port[i] = 0;
+				} else {
+  				allClosed = false;
+				}
+			}
+		}
+		delay(1);
+	}
+	for (uint8_t i=0; i < MAX_SOCK_NUM; i++) {
+		if (server_port[i] == _port) {
+			Ethernet.socketClose(i);
+			server_port[i] = 0;
+		}
+	}
+}
+
 EthernetClient EthernetServer::available()
 {
 	bool listening = false;


### PR DESCRIPTION
In the newest WiFi library WiFiS3 for the Uno R4, there is `end()`, `begin(port)` and ctor without parameter, which I guess officially introduces them into the Arduino networking API.

overview of Server implementations in libraries https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#server-class

