### PR TITLE
Fix the write function to return the actual number of bytes sent.

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -83,7 +83,7 @@ size_t EthernetClient::write(uint8_t b)
 size_t EthernetClient::write(const uint8_t *buf, size_t size)
 {
 	if (_sockindex >= MAX_SOCK_NUM) return 0;
-	if (Ethernet.socketSend(_sockindex, buf, size)) return size;
+	if (size=Ethernet.socketSend(_sockindex, buf, size)) return size;
 	setWriteError();
 	return 0;
 }


### PR DESCRIPTION
The write function was always returning the same count of bytes as was passed in because the size variable was not being assigned the actual number of bytes sent. For example, if I am using a WIZNet 5500 (which limits the send size to 2048 bytes) and I call the function as follows:

`size_t bytesSent = pClient->write(pBuffer, 8192);`

The result returned into the variable **bytesSent** will be 8192, even though only 2048 bytes were actually sent.

The change to `EthernetClient.cpp` in this fork fixes the bug.