### PR TITLE
DhcpAddressPrinter example: Fix initialization with no hardware present

### DIFF
--- a/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
+++ b/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
@@ -42,17 +42,20 @@ void setup() {
 
   // start the Ethernet connection:
   Serial.println("Initialize Ethernet with DHCP:");
+
   if (Ethernet.begin(mac) == 0) {
     Serial.println("Failed to configure Ethernet using DHCP");
-    if (Ethernet.hardwareStatus() == EthernetNoHardware) {
-      Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
-    } else if (Ethernet.linkStatus() == LinkOFF) {
-      Serial.println("Ethernet cable is not connected.");
-    }
-    // no point in carrying on, so do nothing forevermore:
+  }
+  // Check for Ethernet hardware present
+  if (Ethernet.hardwareStatus() == EthernetNoHardware) {
+    Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
+    // do nothing, no point running without Ethernet hardware
     while (true) {
       delay(1);
     }
+  }
+  if (Ethernet.linkStatus() == LinkOFF) {
+    Serial.println("Ethernet cable is not connected.");
   }
   // print your local IP address:
   Serial.print("My IP address: ");


### PR DESCRIPTION
Error message about not present Ethernet hardware was only printed if mac==0, which makes not really sense:

```C
  if (Ethernet.begin(mac) == 0) {
    Serial.println("Failed to configure Ethernet using DHCP");
    if (Ethernet.hardwareStatus() == EthernetNoHardware) {
      Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
    }
```