### PR TITLE
Add hostname parameter to Ethernet.begin

### DIFF
--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -209,6 +209,9 @@ void DhcpClass::send_DHCP_MESSAGE(uint8_t messageType, uint16_t secondsElapsed)
 		printByte((char*)&(buffer[24]), _dhcpMacAddr[3]);
 		printByte((char*)&(buffer[26]), _dhcpMacAddr[4]);
 		printByte((char*)&(buffer[28]), _dhcpMacAddr[5]);
+
+		//put data in W5100 transmit buffer
+		_dhcpUdpSocket.write(buffer, 30);
 	}
 
 	if (messageType == DHCP_REQUEST) {

--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -8,11 +8,17 @@
 
 int DhcpClass::beginWithDHCP(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
 {
-	_dhcpLeaseTime=0;
-	_dhcpT1=0;
-	_dhcpT2=0;
+	return beginWithDHCP(mac, NULL, timeout, responseTimeout);
+}
+
+int DhcpClass::beginWithDHCP(uint8_t *mac, const char* hostName, unsigned long timeout, unsigned long responseTimeout)
+{
+	_dhcpLeaseTime = 0;
+	_dhcpT1 = 0;
+	_dhcpT2 = 0;
 	_timeout = timeout;
 	_responseTimeout = responseTimeout;
+	_hostName = hostName;
 
 	// zero out _dhcpMacAddr
 	memset(_dhcpMacAddr, 0, 6);
@@ -118,7 +124,7 @@ void DhcpClass::presend_DHCP()
 
 void DhcpClass::send_DHCP_MESSAGE(uint8_t messageType, uint16_t secondsElapsed)
 {
-	uint8_t buffer[32];
+	uint8_t buffer[18 + 63]; // Reserve 63 chars for the hostname.
 	memset(buffer, 0, 32);
 	IPAddress dest_addr(255, 255, 255, 255); // Broadcast address
 
@@ -188,15 +194,22 @@ void DhcpClass::send_DHCP_MESSAGE(uint8_t messageType, uint16_t secondsElapsed)
 
 	// OPT - host name
 	buffer[16] = hostName;
-	buffer[17] = strlen(HOST_NAME) + 6; // length of hostname + last 3 bytes of mac address
-	strcpy((char*)&(buffer[18]), HOST_NAME);
 
-	printByte((char*)&(buffer[24]), _dhcpMacAddr[3]);
-	printByte((char*)&(buffer[26]), _dhcpMacAddr[4]);
-	printByte((char*)&(buffer[28]), _dhcpMacAddr[5]);
+	// if a hostname was given use it, use the default otherwise.
+	if (_hostName) {
+		buffer[17] = strlen(_hostName); // length of hostname
+		strncpy((char*)&(buffer[18]), _hostName, strlen(_hostName));
 
-	//put data in W5100 transmit buffer
-	_dhcpUdpSocket.write(buffer, 30);
+		//put data in W5100 transmit buffer
+		_dhcpUdpSocket.write(buffer, 18 + strlen(_hostName));
+	} else {
+		buffer[17] = strlen(HOST_NAME) + 6; // length of hostname + last 3 bytes of mac address
+		strcpy((char*)&(buffer[18]), HOST_NAME);
+
+		printByte((char*)&(buffer[24]), _dhcpMacAddr[3]);
+		printByte((char*)&(buffer[26]), _dhcpMacAddr[4]);
+		printByte((char*)&(buffer[28]), _dhcpMacAddr[5]);
+	}
 
 	if (messageType == DHCP_REQUEST) {
 		buffer[0] = dhcpRequestedIPaddr;

--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -28,6 +28,14 @@ DhcpClass* EthernetClass::_dhcp = NULL;
 
 int EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
 {
+	return begin(mac,
+				 NULL,
+				 timeout,
+				 responseTimeout);
+}
+
+int EthernetClass::begin(uint8_t *mac, const char* hostName, unsigned long timeout, unsigned long responseTimeout)
+{
 	static DhcpClass s_dhcp;
 	_dhcp = &s_dhcp;
 
@@ -39,7 +47,7 @@ int EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long resp
 	SPI.endTransaction();
 
 	// Now try to get our config info from a DHCP server
-	int ret = _dhcp->beginWithDHCP(mac, timeout, responseTimeout);
+	int ret = _dhcp->beginWithDHCP(mac, hostName, timeout, responseTimeout);
 	if (ret == 1) {
 		// We've successfully found a DHCP server and got our configuration
 		// info, so set things accordingly

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -47,8 +47,6 @@
 // does not always seem to work in practice (maybe WIZnet bugs?)
 //#define ETHERNET_LARGE_BUFFERS
 
-#include <string>
-
 #include <Arduino.h>
 
 #include "Client.h"

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -47,8 +47,10 @@
 // does not always seem to work in practice (maybe WIZnet bugs?)
 //#define ETHERNET_LARGE_BUFFERS
 
+#include <string>
 
 #include <Arduino.h>
+
 #include "Client.h"
 #include "Server.h"
 #include "Udp.h"
@@ -80,6 +82,7 @@ public:
 	// gain the rest of the configuration through DHCP.
 	// Returns 0 if the DHCP configuration failed, and 1 if it succeeded
 	static int begin(uint8_t *mac, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
+	static int begin(uint8_t *mac, const char* hostName, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
 	static int maintain();
 	static EthernetLinkStatus linkStatus();
 	static EthernetHardwareStatus hardwareStatus();
@@ -303,7 +306,7 @@ private:
 	void presend_DHCP();
 	void send_DHCP_MESSAGE(uint8_t, uint16_t);
 	void printByte(char *, uint8_t);
-
+	const char* _hostName;
 	uint8_t parseDHCPResponse(unsigned long responseTimeout, uint32_t& transactionId);
 public:
 	IPAddress getLocalIp();
@@ -313,6 +316,7 @@ public:
 	IPAddress getDnsServerIp();
 
 	int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
+	int beginWithDHCP(uint8_t *, const char* hostName, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
 	int checkLease();
 };
 


### PR DESCRIPTION
This adds an option to specify the hostname to use with DHCP to the Ethernet.begin method.
The default hostname can still be used.