### PR TITLE
WizEthernet.h added to allow specifying exactly this library

### DIFF
--- a/src/WizEthernet.h
+++ b/src/WizEthernet.h
@@ -1,0 +1,1 @@
+#include "Ethernet.h"


### PR DESCRIPTION
WizEthernet.h added to allow specifying exactly this library to use this library instead of the platform's Ethernet lib