### PR TITLE
(ethernet_server): Refactor EthernetServer and fix initialization bug

### DIFF
--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -254,6 +254,7 @@ private:
 class EthernetServer : public Server {
 private:
 	uint16_t _port;
+	void _socketCleanup();
 public:
 	EthernetServer(uint16_t port) : _port(port) { }
 	EthernetClient available();


### PR DESCRIPTION
This PR implements significant refactoring and stabilization for the `EthernetServer` class to handle hardware limits and TCP state transitions more robustly.

**Summary of Improvements:**

1.  **Code Abstraction:** The repetitive W5100 4-socket limit check is abstracted into the `WIZNET_CHIP_LIMIT` macro, reducing redundant code in `available()`, `accept()`, `write()`, and `operator bool()`.
2.  **Centralized Cleanup:** Introduces a private helper, `void _socketCleanup()`, to handle client disconnections (`CLOSE_WAIT`) and close out unused `CLOSED` sockets, making the main public methods cleaner and more focused on their primary duties.
3.  **Bug Fix (Server Initialization):** Corrects `EthernetServer::begin()` to use `Ethernet.socketClose()` (instead of `socketDisconnect()`) if the initial `socketListen` fails, ensuring the socket is correctly returned to the available pool.
4.  **Bug Fix (Write Function):** Fixes a critical bug in `write(const uint8_t*, size_t)` where it now correctly accumulates and returns the actual `sent_data` length, rather than returning the requested buffer `size` regardless of success.
5.  **Compilation Fix:** Ensures the `chip` variable is correctly declared in `operator bool()` to satisfy the requirements of the `WIZNET_CHIP_LIMIT` macro.