### PR TITLE
Fix: Clear W5100 IP address on DHCP lease failure

### DIFF
--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -135,6 +135,14 @@ int EthernetClass::maintain()
 			SPI.endTransaction();
 			_dnsServerAddress = _dhcp->getDnsServerIp();
 			break;
+		case DHCP_CHECK_RENEW_FAIL:
+		case DHCP_CHECK_REBIND_FAIL:
+			// Lease renewal failed; IP is no longer valid.
+			// Stop using the IP address to avoid conflicts.
+			SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+			W5100.setIPAddress(IPAddress(0,0,0,0).raw_address());
+			SPI.endTransaction();
+			break;
 		default:
 			//this is actually an error, it will retry though
 			break;


### PR DESCRIPTION
This addresses the issue where the device retains a stale, invalid IP address after DHCP lease renewal fails (DHCP_CHECK_RENEW_FAIL or DHCP_CHECK_REBIND_FAIL), which could cause network conflicts or connection issues. The fix sets the IP to 0.0.0.0.