### PR TITLE
Refactor: Simplify DhcpClass::printByte for hex conversion

### DIFF
--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -422,12 +422,9 @@ IPAddress DhcpClass::getDnsServerIp()
 
 void DhcpClass::printByte(char * buf, uint8_t n )
 {
-	char *str = &buf[1];
-	buf[0]='0';
-	do {
-		unsigned long m = n;
-		n /= 16;
-		char c = m - 16 * n;
-		*str-- = c < 10 ? c + '0' : c + 'A' - 10;
-	} while(n);
+	uint8_t high_nibble = (n >> 4) & 0x0F;
+	uint8_t low_nibble = n & 0x0F;
+
+	buf[0] = high_nibble < 10 ? high_nibble + '0' : high_nibble + 'A' - 10;
+	buf[1] = low_nibble < 10 ? low_nibble + '0' : low_nibble + 'A' - 10;
 }


### PR DESCRIPTION
This change replaces the loop-based, pointer-decrementing hex conversion logic with a clear, direct approach using bitwise operations (>> 4 and & 0x0F) to generate the two-character hex string. This is cleaner and less error-prone.