### PR TITLE
Add Ethernet.setHostname method and make DHCP hostname configurable.

### DIFF
--- a/examples/DhcpCustomHostname/DhcpCustomHostname.ino
+++ b/examples/DhcpCustomHostname/DhcpCustomHostname.ino
@@ -1,0 +1,95 @@
+/*
+  DHCP with custom hostname
+
+  This sketch uses the DHCP extensions to the Ethernet library
+  to get an IP address via DHCP and print the address obtained.
+  using an Arduino WIZnet Ethernet shield.
+
+  It demonstrates how to set a custom hostname for the DHCP request.
+
+  Circuit:
+   Ethernet shield attached to pins 10, 11, 12, 13
+
+  created 14 December 2025
+  by Dmytro Lahoza
+ */
+
+#include <SPI.h>
+#include <Ethernet.h>
+
+// Enter a MAC address for your controller below.
+// Newer Ethernet shields have a MAC address printed on a sticker on the shield
+byte mac[] = {
+  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
+};
+
+void setup() {
+  // You can use Ethernet.init(pin) to configure the CS pin
+  //Ethernet.init(10);  // Most Arduino shields
+  //Ethernet.init(5);   // MKR ETH Shield
+  //Ethernet.init(0);   // Teensy 2.0
+  //Ethernet.init(20);  // Teensy++ 2.0
+  //Ethernet.init(15);  // ESP8266 with Adafruit FeatherWing Ethernet
+  //Ethernet.init(33);  // ESP32 with Adafruit FeatherWing Ethernet
+
+  // Open serial communications and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // Set the hostname for the DHCP request
+  Ethernet.setHostname("arduino-ethernet");
+
+  // start the Ethernet connection:
+  Serial.println("Initialize Ethernet with DHCP:");
+  if (Ethernet.begin(mac) == 0) {
+    Serial.println("Failed to configure Ethernet using DHCP");
+    if (Ethernet.hardwareStatus() == EthernetNoHardware) {
+      Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
+    } else if (Ethernet.linkStatus() == LinkOFF) {
+      Serial.println("Ethernet cable is not connected.");
+    }
+    // no point in carrying on, so do nothing forevermore:
+    while (true) {
+      delay(1);
+    }
+  }
+  // print your local IP address:
+  Serial.print("My IP address: ");
+  Serial.println(Ethernet.localIP());
+}
+
+void loop() {
+  switch (Ethernet.maintain()) {
+    case 1:
+      //renewed fail
+      Serial.println("Error: renewed fail");
+      break;
+
+    case 2:
+      //renewed success
+      Serial.println("Renewed success");
+      //print your local IP address:
+      Serial.print("My IP address: ");
+      Serial.println(Ethernet.localIP());
+      break;
+
+    case 3:
+      //rebind fail
+      Serial.println("Error: rebind fail");
+      break;
+
+    case 4:
+      //rebind success
+      Serial.println("Rebind success");
+      //print your local IP address:
+      Serial.print("My IP address: ");
+      Serial.println(Ethernet.localIP());
+      break;
+
+    default:
+      //nothing happened
+      break;
+  }
+}

--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -25,11 +25,15 @@
 
 IPAddress EthernetClass::_dnsServerAddress;
 DhcpClass* EthernetClass::_dhcp = NULL;
+char EthernetClass::_hostname[32] = {0};
 
 int EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
 {
 	static DhcpClass s_dhcp;
 	_dhcp = &s_dhcp;
+	if (_hostname[0] != 0) {
+		_dhcp->setCustomHostname(_hostname);
+	}
 
 	// Initialise the basic info
 	if (W5100.init() == 0) return 0;
@@ -176,6 +180,16 @@ IPAddress EthernetClass::gatewayIP()
 	W5100.getGatewayIp(ret.raw_address());
 	SPI.endTransaction();
 	return ret;
+}
+
+void EthernetClass::setHostname(const char* hostname)
+{
+	if (strlen(hostname) < 32) {
+		strcpy(_hostname, hostname);
+		if (_dhcp) {
+			_dhcp->setCustomHostname(_hostname);
+		}
+	}
 }
 
 void EthernetClass::setMACAddress(const uint8_t *mac_address)

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -75,6 +75,7 @@ class EthernetClass {
 private:
 	static IPAddress _dnsServerAddress;
 	static DhcpClass* _dhcp;
+	static char _hostname[32];
 public:
 	// Initialise the Ethernet shield to use the provided MAC address and
 	// gain the rest of the configuration through DHCP.
@@ -97,6 +98,7 @@ public:
 	static IPAddress gatewayIP();
 	static IPAddress dnsServerIP() { return _dnsServerAddress; }
 
+	void setHostname(const char* hostname);
 	void setMACAddress(const uint8_t *mac_address);
 	void setLocalIP(const IPAddress local_ip);
 	void setSubnetMask(const IPAddress subnet);
@@ -297,6 +299,7 @@ private:
 	unsigned long _lastCheckLeaseMillis;
 	uint8_t _dhcp_state;
 	EthernetUDP _dhcpUdpSocket;
+	const char *_dhcpHostname = NULL;
 
 	int request_DHCP_lease();
 	void reset_DHCP_lease();
@@ -311,6 +314,7 @@ public:
 	IPAddress getGatewayIp();
 	IPAddress getDhcpServerIp();
 	IPAddress getDnsServerIp();
+	void setCustomHostname(const char* name);
 
 	int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
 	int checkLease();


### PR DESCRIPTION
- Added Ethernet.setHostname(const char* hostname) method.
- Increased DHCP buffer size to 64 bytes to accommodate variable hostname length.
- Updated DhcpClass to use the custom hostname.