### PR TITLE
Fix DHCP checkLease() double-blocking and add yield() to polling loops

### DIFF
--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -51,6 +51,7 @@ int DhcpClass::request_DHCP_lease()
 	unsigned long startTime = millis();
 
 	while (_dhcp_state != STATE_DHCP_LEASED) {
+		yield();
 		if (_dhcp_state == STATE_DHCP_START) {
 			_dhcpTransactionId++;
 			send_DHCP_MESSAGE(DHCP_DISCOVER, ((millis() - startTime) / 1000));
@@ -245,6 +246,7 @@ uint8_t DhcpClass::parseDHCPResponse(unsigned long responseTimeout, uint32_t& tr
 			return 255;
 		}
 		delay(50);
+		yield();
 	}
 	// start reading in the packet
 	RIP_MSG_FIXED fixedMsg;
@@ -385,7 +387,7 @@ int DhcpClass::checkLease()
 	}
 
 	// if we have a lease or is renewing but should bind, do it
-	if (_rebindInSec == 0 && (_dhcp_state == STATE_DHCP_LEASED ||
+	else if (_rebindInSec == 0 && (_dhcp_state == STATE_DHCP_LEASED ||
 	  _dhcp_state == STATE_DHCP_START)) {
 		// this should basically restart completely
 		_dhcp_state = STATE_DHCP_START;


### PR DESCRIPTION
## Summary

Two bugs in `Dhcp.cpp` that cause unexpectedly long blocking during DHCP lease renewal, triggering hardware watchdog resets on systems with WDT enabled.

### Bug 1: `checkLease()` can call `request_DHCP_lease()` twice in one invocation

`checkLease()` has two consecutive `if` blocks — one for renew (T1) and one for rebind (T2):

```cpp
// renew
if (_renewInSec == 0 && _dhcp_state == STATE_DHCP_LEASED) {
    _dhcp_state = STATE_DHCP_REREQUEST;
    rc = 1 + request_DHCP_lease();
}

// rebind
if (_rebindInSec == 0 && (_dhcp_state == STATE_DHCP_LEASED ||
  _dhcp_state == STATE_DHCP_START)) {
    _dhcp_state = STATE_DHCP_START;
    reset_DHCP_lease();
    rc = 3 + request_DHCP_lease();
}
```

When the renew attempt **fails**, `request_DHCP_lease()` leaves `_dhcp_state` as `STATE_DHCP_START` (via the `messageType == 255` timeout fallback at line 98-100). The second `if` then matches on `STATE_DHCP_START` and fires `request_DHCP_lease()` again in the same call. This chains two full blocking DHCP exchanges back-to-back.

This happens reliably when both `_renewInSec` and `_rebindInSec` reach 0 in the same `checkLease()` call, which occurs when `checkLease()` hasn't been called for longer than T2 (e.g., after a long blocking operation elsewhere in the sketch).

**Fix:** Change the second `if` to `else if`. This preserves the original intent (try renew first, fall back to rebind) while preventing double execution.

### Bug 2: Missing `yield()` in DHCP polling loops

`parseDHCPResponse()` polls for incoming packets in a `delay(50)` loop that can run for up to `_responseTimeout` milliseconds. `request_DHCP_lease()` iterates a state machine that calls `parseDHCPResponse()` multiple times. Neither loop calls `yield()`.

Other parts of the library already use `yield()` in their blocking loops — `EthernetClient::connect()` (line 53), `socket.cpp` etc. — but `Dhcp.cpp` was missed.

**Fix:** Add `yield()` in both loops, consistent with the rest of the library.

## Impact

With default timeouts (`_timeout = 60000`, `_responseTimeout = 4000`), a single `request_DHCP_lease()` call can block for up to 60 seconds. The double-fire in bug 1 doubles this. Combined with bug 2 (no `yield()` to feed cooperative schedulers/watchdogs), this can cause:

- Hardware watchdog resets (AVR, STM32, etc.)
- ESP8266/ESP32 software watchdog resets (these rely on `yield()`)
- Unresponsive sketches during lease renewal

## How We Found This

Discovered in a 24/7 production system (Teensy++ 2.0 / AT90USB1286 with W5500 Ethernet and 8-second hardware watchdog). Diagnostic logging captured `maxLoop` values of 12-21 seconds during DHCP lease renewal periods, always correlated with `Ethernet.maintain()` returning status 3 or 4 (rebind). After patching, the system has been stable with no further watchdog resets.

## Test Plan

- Verified fix on AT90USB1286 + W5500 in 24/7 operation over multiple days
- Confirmed `checkLease()` no longer double-fires when both timers expire simultaneously
- Confirmed `yield()` is called during DHCP response polling, preventing watchdog starvation


Made with [Cursor](https://cursor.com)